### PR TITLE
FIX : missing GETPOST check parameters (none)

### DIFF
--- a/admin/dispatch_to_supplier_order_setup.php
+++ b/admin/dispatch_to_supplier_order_setup.php
@@ -51,7 +51,7 @@ $action = GETPOST('action', 'alpha');
 if (preg_match('/set_(.*)/',$action,$reg))
 {
     $code=$reg[1];
-    if (dolibarr_set_const($db, $code, GETPOST($code), 'chaine', 0, '', $conf->entity) > 0)
+    if (dolibarr_set_const($db, $code, GETPOST($code, 'none'), 'chaine', 0, '', $conf->entity) > 0)
     {
         header("Location: ".$_SERVER["PHP_SELF"]);
         exit;
@@ -91,67 +91,67 @@ llxHeader('', $langs->trans($page_name));
         0,
         "supplierorderfromorder@supplierorderfromorder"
         );
-    
-    
-    
+
+
+
     $linkback='<a href="'.DOL_URL_ROOT.'/admin/modules.php">'.$langs->trans("BackToModuleList").'</a>';
     print_fiche_titre($langs->trans("SupplierOrderFromOrder"),$linkback,'supplierorderfromorder@supplierorderfromorder');
-    
-    
+
+
     dol_fiche_end();
-    
-    
+
+
     // Setup page goes here
     $form=new Form($db);
     $var=false;
     print '<table class="noborder" width="100%">';
-    
-    
+
+
     if(!function_exists('setup_print_title')){
         print '<div class="error" >'.$langs->trans('AbricotNeedUpdate').' : <a href="http://wiki.atm-consulting.fr/index.php/Accueil#Abricot" target="_blank"><i class="fa fa-info"></i> Wiki</a></div>';
         exit;
     }
-    
+
     setup_print_title("Parameters");
-    
+
     // USE Nomenclature tab
     setup_print_on_off('SOFO_USE_NOMENCLATURE',false, '', 'SOFO_USE_NOMENCLATURE_HELP');
-    
-    
+
+
     setup_print_title("ParametersNeedSOFO_USE_NOMENCLATURE");
-    
+
     // Fill qty for nomenclature
     setup_print_on_off('SOFO_FILL_QTY_NOMENCLATURE',false);
-    
+
     // Disable product order if nomenclature
     setup_print_on_off('SOFO_DISABLE_ORDER_POSIBILITY_TO_PRODUCT_WITH_NOMENCLATURE');
-    
-    
+
+
     // USE DELIVERY CONTACT
     setup_print_on_off('SOFO_USE_DELIVERY_CONTACT',false, '', 'DeliveryHelp');
-    
-    
+
+
     // USE RESTRICTION CONTACT
     setup_print_on_off('SOFO_USE_RESTRICTION_TO_CUSTOMER_ORDER');
-    
+
     setup_print_on_off('SOFO_ADD_QUANTITY_RATHER_THAN_CREATE_LINES');
-    
-    
+
+
     // Example with imput
     //setup_print_input_form_part('CONSTNAME', 'ParamLabel');
-    
+
     // Example with color
    // setup_print_input_form_part('CONSTNAME', 'ParamLabel', 'ParamDesc', array('type'=>'color'),'input','ParamHelp');
-    
+
     // Example with placeholder
     //setup_print_input_form_part('CONSTNAME','ParamLabel','ParamDesc',array('placeholder'=>'http://'),'input','ParamHelp');
-    
+
     // Example with textarea
     //setup_print_input_form_part('CONSTNAME','ParamLabel','ParamDesc',array(),'textarea');
-    
-    
+
+
     print '</table>';
-    
+
     llxFooter();
-    
+
     $db->close();

--- a/admin/supplierorderfromorder_setup.php
+++ b/admin/supplierorderfromorder_setup.php
@@ -15,8 +15,8 @@ global $db;
 // Security check
 if (! $user->admin) accessforbidden();
 
-$action=GETPOST('action');
-$id=GETPOST('id');
+$action=GETPOST('action', 'alpha');
+$id=GETPOST('id', 'int');
 
 /*
  * Action
@@ -25,7 +25,7 @@ if (preg_match('/set_(.*)/',$action,$reg))
 {
 	$code=$reg[1];
 
-	$value = GETPOST($code);
+	$value = GETPOST($code, 'none');
 
 	if($code == 'SOFO_DEFAULT_PRODUCT_CATEGORY_FILTER') {
 
@@ -50,7 +50,7 @@ if (preg_match('/set_(.*)/',$action,$reg))
 	if (dolibarr_set_const($db, $code, $value, 'chaine', 0, '', $conf->entity) > 0)
 	{
 
-		if($code=='SOFO_USE_DELIVERY_TIME' && GETPOST($code) == 1) {
+		if($code=='SOFO_USE_DELIVERY_TIME' && GETPOST($code, 'none') == 1) {
 
 			dolibarr_set_const($db,'FOURN_PRODUCT_AVAILABILITY',1);
 		}

--- a/cbn.php
+++ b/cbn.php
@@ -161,7 +161,7 @@ if ($snom) {
 
 $sql .= ' AND p.tobuy = 1';
 
-$finished = GETPOST('finished');
+$finished = GETPOST('finished', 'none');
 if($finished != '' && $finished != '-1') $sql .= ' AND p.finished = '.$finished;
 elseif(!isset($_REQUEST['button_search_x']) && isset($conf->global->SOFO_DEFAUT_FILTER) && $conf->global->SOFO_DEFAUT_FILTER >= 0) $sql .= ' AND p.finished = '.$conf->global->SOFO_DEFAUT_FILTER;
 
@@ -282,7 +282,7 @@ if ($resql || $resql2) {
          '<input type="hidden" name="linecount" value="' . ($num+$num2) . '">'.
          '<input type="hidden" name="action" value="order">'.
          '<input type="hidden" name="fk_commande" value="' . GETPOST('fk_commande','int'). '">'.
-         '<input type="hidden" name="show_stock_no_need" value="' . GETPOST('show_stock_no_need'). '">'.
+         '<input type="hidden" name="show_stock_no_need" value="' . GETPOST('show_stock_no_need', 'none'). '">'.
 
          '<div style="text-align:right"><a href="'.$_SERVER["PHP_SELF"].'?'.$_SERVER["QUERY_STRING"].'&show_stock_no_need=yes">'.$langs->trans('ShowLineEvenIfStockIsSuffisant').'</a></div>'.
          '<table class="liste" width="100%">';
@@ -456,7 +456,7 @@ if ($resql || $resql2) {
     }
 
 	$liste_titre = "";
-	$liste_titre.= '<td class="liste_titre">'.$form->selectarray('finished',$statutarray,(!isset($_REQUEST['button_search_x']) && $conf->global->SOFO_DEFAUT_FILTER != -1) ? $conf->global->SOFO_DEFAUT_FILTER : GETPOST('finished'),1).'</td>';
+	$liste_titre.= '<td class="liste_titre">'.$form->selectarray('finished',$statutarray,(!isset($_REQUEST['button_search_x']) && $conf->global->SOFO_DEFAUT_FILTER != -1) ? $conf->global->SOFO_DEFAUT_FILTER : GETPOST('finished', 'none'),1).'</td>';
     $liste_titre.= $dolibarr_version35 ? '<td class="liste_titre">&nbsp;</td>' : '';
     $liste_titre.= '<td class="liste_titre" align="right">' . $langs->trans('AlertOnly') . '&nbsp;<input type="checkbox" name="salert" ' . $alertchecked . '></td>';
 
@@ -638,7 +638,7 @@ if ($resql || $resql2) {
                                 $qres = $db->query($q);
 
                                 while($res = $db->fetch_object($qres)) $TDemandes[] = $res->ref;
-                        
+
                         	}
 
 
@@ -656,7 +656,7 @@ if ($resql || $resql2) {
 				$qres = $db->query($q);
 
 				while($res = $db->fetch_object($qres)) $TDemandes[] = $res->ref;
-			
+
           		}
 			}
 
@@ -706,7 +706,7 @@ if ($resql || $resql2) {
 
 			if($stocktobuy < 0) $stocktobuy = 0;
 
-			if($stocktobuy == 0 && GETPOST('show_stock_no_need')!='yes') {
+			if($stocktobuy == 0 && GETPOST('show_stock_no_need', 'none')!='yes') {
 				$i++;
 				continue;
 			}
@@ -800,7 +800,7 @@ if ($resql || $resql2) {
 //	if($prod->ref=='A0000753') exit;
 
         flush();
-        
+
         $i++;
     }
 

--- a/dispatch_to_supplier_order.php
+++ b/dispatch_to_supplier_order.php
@@ -21,15 +21,15 @@ $langs->loadLangs(array(
     ,'products'
     , 'stocks'
     ,'supplierorderfromorder@supplierorderfromorder'
-    
+
 ));
 
 
 
 
-$action = GETPOST('action');
+$action = GETPOST('action', 'alpha');
 $fromid = GETPOST('fromid', 'int');
-$from = GETPOST('from');
+$from = GETPOST('from', 'none');
 $TDispatch = array();
 
 if(empty($action)){
@@ -80,31 +80,31 @@ if ($reshook < 0) setEventMessages($hookmanager->error, $hookmanager->errors, 'e
 
 if (empty($reshook))
 {
-	// do action from GETPOST ... 
+	// do action from GETPOST ...
 	if($action == 'dispatch')
 	{
 
-	    
+
 	    $saveconf_SUPPLIER_ORDER_WITH_NOPRICEDEFINED = !empty($conf->global->SUPPLIER_ORDER_WITH_NOPRICEDEFINED)?$conf->global->SUPPLIER_ORDER_WITH_NOPRICEDEFINED:0 ;
 	    $conf->global->SUPPLIER_ORDER_WITH_NOPRICEDEFINED = 1;
-	    
+
 
         foreach ($origin->lines as $i => $line)
         {
-            
+
             if(!empty($TChecked) && in_array($line->id, $TChecked))
             {
-               
-                
-                
-                
+
+
+
+
                 $array_options = array();
                 if(!empty($TShipping[$line->id])) $TShipping = array_map('intval', $TShipping);
-                
 
-                
+
+
                 $supplierSocId = GETPOST('fk_soc_fourn_'.$line->id, 'int');
-                
+
                 // Get fourn from supplier price
                 if(isset($Tproductfournpriceid[$line->id])){
                     $prod_supplier = new ProductFournisseur($db);
@@ -115,64 +115,64 @@ if (empty($reshook))
                             'status' => -1,
                             'msg' => $langs->trans('ErrorPriceDoesNotExist').' : '.$Tproductfournpriceid[$line->id]
                         );
-                        
+
                         continue;
                     }
-                    
+
                     if(!empty($prod_supplier->fourn_id))
                     {
                         $supplierSocId = $prod_supplier->fourn_id;
                     }
-                    
+
                 }
-                
-                
-                
+
+
+
                 if(empty($supplierSocId) && ( empty($TDispatch[$line->id]['status']) || $TDispatch[$line->id]['status'] < 0) ){
                     $TDispatch[$line->id] = array(
                         'status' => -1,
                         'msg' => $langs->trans('ErrorFournDoesNotExist').' : '.$supplierSocId
                     );
-                    
+
                     continue;
                 }
-                
-                
-                
-                
-                
+
+
+
+
+
                 // vérification si la ligne fait déjà l'objet d'une commande fournisseur
                 $searchSupplierOrderLine = getLinkedSupplierOrdersLinesFromElementLine($line->id);
-                
+
                 if(empty($searchSupplierOrderLine))
                 {
                     $createNewOrder = true;
-                    
+
                     $shippingContactId = 0;
                     if(!empty($TShipping[$line->id])){
                         $shippingContactId = $TShipping[$line->id];
                     }
-                    
+
                     $societe = new Societe($db);
                     $societe->fetch($supplierSocId);
-                    
-                    
+
+
                     // search and get draft supplier order linked
                     $searchSupplierOrder = getLinkedSupplierOrderFromOrder($line->fk_commande,$supplierSocId,$shippingContactId,CommandeFournisseur::STATUS_DRAFT,$array_options);
                     if(empty($searchSupplierOrder))
                     {
-                        // search draft supplier order with same critera 
+                        // search draft supplier order with same critera
                         $restrictToCustomerOrder=0;
                         if(!empty($conf->global->SOFO_USE_RESTRICTION_TO_CUSTOMER_ORDER)){
                             $restrictToCustomerOrder = $origin->id;
                         }
-                        
+
                         $searchSupplierOrder = getSupplierOrderAvailable($supplierSocId,$shippingContactId,$array_options,$restrictToCustomerOrder);
                     }
-                    
-                    
+
+
                     $CommandeFournisseur = new CommandeFournisseur($db);
-                    
+
                     if(!empty($searchSupplierOrder))
                     {
                         $CommandeFournisseur->fetch($searchSupplierOrder[0]);
@@ -189,15 +189,15 @@ if (empty($reshook))
                             if(!empty($TShipping[$line->id])){
                                 $CommandeFournisseur->add_contact($TShipping[$line->id], 'SHIPPING');
                             }
-                            
+
                             // add order in linked element
                             $CommandeFournisseur->add_object_linked('commande', $origin->id);
-                            
+
                         }
                     }
-                    
-                    
-                    
+
+
+
                     // Vérification de la commande
                     if(empty($CommandeFournisseur->id))
                     {
@@ -206,11 +206,11 @@ if (empty($reshook))
 	                        'status' => -1,
 	                        'msg' => $langs->trans('ErrorOrderDoesNotExist')
 	                    );
-                    
+
                        continue;
                     }
-                    
-                   
+
+
                     // GET PRICE
                     $fk_prod_fourn_price =0;
                     $ref_supplier=$line->ref_fourn;
@@ -218,11 +218,11 @@ if (empty($reshook))
                     $price = 0;
                     $qty = isset($Tqty[$line->id])?$Tqty[$line->id]:$line->qty;
                     $tva_tx = $line->tva_tx;
-                    
+
                     if(!empty($TfournUnitPrice[$line->id])){
                         $price = price2num($TfournUnitPrice[$line->id]);
                     }
-                    
+
                     // Get subprice from product
                     if(!empty($line->fk_product)){
                         $ProductFournisseur = new ProductFournisseur($db);
@@ -239,8 +239,8 @@ if (empty($reshook))
                     if(empty($price) && !empty($line->pa_ht) ){
                         $price = $line->pa_ht;
                     }
-                   
-                    
+
+
                     // SEARCH in supplier order if same product exist
                     $supplierLineRowidExist = 0 ;
                     if(!empty($CommandeFournisseur->lines) && $conf->global->SOFO_ADD_QUANTITY_RATHER_THAN_CREATE_LINES)
@@ -257,11 +257,11 @@ if (empty($reshook))
                             }
                         }
                     }
-                    
+
                     // UPDATE SUPPLIER LINE
                     if($supplierLineRowidExist>0)
                     {
-                        
+
                         $updateRes = $CommandeFournisseur->updateline(
                             $fournLine->id,
                             $fournLine->desc,
@@ -282,16 +282,16 @@ if (empty($reshook))
                             0, // $pu_ht_devise
                             $fournLine->ref_supplier
                             );
-                        
-                        
-                        
+
+
+
                         if($updateRes>=0) // yes $CommandeFournisseur->updateline can return 0 on success
                         {
                             // add order line in linked element
                             $commandeFournisseurLigne = new CommandeFournisseurLigne($db);
                             $commandeFournisseurLigne->fetch($addRes);
                             $commandeFournisseurLigne->add_object_linked('commandedet', $line->id);
-                            
+
                             // sauvegarde des infos pour l'affichage du resultat
                             $TDispatch[$line->id] = array(
                                 'status' => 1,
@@ -335,16 +335,16 @@ if (empty($reshook))
                             'commandedet', //$origin= // peut être un jour ça sera géré...
                             $line->id //$origin_id=0 // peut être un jour ça sera géré...
                             );
-                        
-                        
+
+
                         if($addRes>0)
                         {
-                            
+
                             // add order line in linked element
                             $commandeFournisseurLigne = new CommandeFournisseurLigne($db);
                             $commandeFournisseurLigne->fetch($addRes);
                             $commandeFournisseurLigne->add_object_linked('commandedet', $line->id);
-                            
+
                             // sauvegarde des infos pour l'affichage du resultat
                             $TDispatch[$line->id] = array(
                                 'status' => 1,
@@ -361,46 +361,46 @@ if (empty($reshook))
                             );
                         }
                     }
-                    
-                    
-                    
-                    
-                    
-                    
+
+
+
+
+
+
                 }
             }
-            
-            
-            
+
+
+
             /**********************/
             /* NOMENCLATURE PART  */
             /**********************/
-            
-            // Note pour PH : j'ai pas factorisé avec les lignes standards car j'ai le sentiment que pleins de choses vont êtres ajoutées... et pour le coup la factorisation risque de complexifier pour rien... pour l'instant je veux garder un truc à peu près lisible 
-            
+
+            // Note pour PH : j'ai pas factorisé avec les lignes standards car j'ai le sentiment que pleins de choses vont êtres ajoutées... et pour le coup la factorisation risque de complexifier pour rien... pour l'instant je veux garder un truc à peu près lisible
+
             if(!empty($TCheckedNomenclature[$line->id]) && is_array($TCheckedNomenclature[$line->id]))
             {
                 // Nomenclature
                 foreach($TCheckedNomenclature[$line->id] as $nomenclatureI)
                 {
-                   
+
                     /*$TNomenclature_productfournpriceid[$line->id][$nomenclatureI];
                     $TNomenclature_qty[$line->id][$nomenclatureI];
                     $TNomenclature_fournUnitPrice[$line->id][$nomenclatureI];*/
-                    
-                    
+
+
                     $forceSupplierSocId = GETPOST('force_nomenclature_fk_soc_fourn_'.$line->id, 'int');
-                    
+
                     if(empty($TNomenclature_productfournproductid[$line->id][$nomenclatureI]) && empty($forceSupplierSocId))
                     {
                         $TDispatchNomenclature[$line->id][$nomenclatureI] = array(
                             'status' => -1,
                             'msg' => $langs->trans('ErrorNoProduct').' : '.$nomenclatureI
                         );
-                        
+
                         continue;
                     }
-                    
+
                     $product = new Product($db);
                     if( $product->fetch((int)$TNomenclature_productfournproductid[$line->id][$nomenclatureI])  < 1 )
                     {
@@ -408,13 +408,13 @@ if (empty($reshook))
                             'status' => -1,
                             'msg' => $langs->trans('ErrorNoProductFound').' : '.$TNomenclature_productfournproductid[$line->id][$nomenclatureI]
                         );
-                        
+
                         continue;
                     }
-                    
-                    
-                    
-                    
+
+
+
+
                     $supplierSocId = GETPOST('fk_soc_fourn_'.$line->id.'_n'.$nomenclatureI, 'int');
 
                     if(!empty($forceSupplierSocId)){
@@ -431,41 +431,41 @@ if (empty($reshook))
                                 'status' => -1,
                                 'msg' => $langs->trans('ErrorPriceDoesNotExist').' : '.$TNomenclature_productfournpriceid[$line->id][$nomenclatureI]
                             );
-                            
+
                             continue;
                         }
-                        
+
                         if(!empty($prod_supplier->fourn_id))
                         {
                             $supplierSocId = $prod_supplier->fourn_id;
                         }
-                        
+
                     }
-                    
+
 
                     if(empty($supplierSocId) && ( empty($TDispatchNomenclature[$line->id][$nomenclatureI]['status']) || $TDispatchNomenclature[$line->id][$nomenclatureI]['status'] < 0) ){
                         $TDispatchNomenclature[$line->id][$nomenclatureI] = array(
                             'status' => -1,
                             'msg' => $langs->trans('ErrorFournDoesNotExist').' : '.$supplierSocId
                         );
-                        
+
                         continue;
                     }
-                    
+
 
                     // vérification si la ligne fait déjà l'objet d'une commande fournisseur
-                    $searchSupplierOrderLine = false; // TODO : find a way to detect this for nomenclature 
-                    
+                    $searchSupplierOrderLine = false; // TODO : find a way to detect this for nomenclature
+
                     if(empty($searchSupplierOrderLine))
                     {
                         $createNewOrder = true;
-                        
+
                         $shippingContactId = 0; // Les produits issue d'une nomenclature ne doivent pas partir dirrectement chez un client (pour l'instant en tout cas)
-                        
+
                         $societe = new Societe($db);
                         $societe->fetch($supplierSocId);
-                        
-                        
+
+
                         // search and get draft supplier order linked
                         $searchSupplierOrder = getLinkedSupplierOrderFromOrder($line->fk_commande,$supplierSocId,$shippingContactId,CommandeFournisseur::STATUS_DRAFT,$array_options);
                         if(empty($searchSupplierOrder))
@@ -475,14 +475,14 @@ if (empty($reshook))
                             if(!empty($conf->global->SOFO_USE_RESTRICTION_TO_CUSTOMER_ORDER)){
                                 $restrictToCustomerOrder = $origin->id;
                             }
-                            
+
                             // search draft supplier order with same critera
                             $searchSupplierOrder = getSupplierOrderAvailable($supplierSocId,$shippingContactId,$array_options);
                         }
-                        
-                        
+
+
                         $CommandeFournisseur = new CommandeFournisseur($db);
-                        
+
                         if(!empty($searchSupplierOrder))
                         {
                             $CommandeFournisseur->fetch($searchSupplierOrder[0]);
@@ -499,9 +499,9 @@ if (empty($reshook))
                                 $CommandeFournisseur->add_object_linked('commande', $origin->id);
                             }
                         }
-                        
-                        
-                        
+
+
+
                         // Vérification de la commande
                         if(empty($CommandeFournisseur->id))
                         {
@@ -510,11 +510,11 @@ if (empty($reshook))
                                 'status' => -1,
                                 'msg' => $langs->trans('ErrorOrderDoesNotExist')
                             );
-                            
+
                             continue;
                         }
-                        
-                        
+
+
                         // GET PRICE
                         $fk_prod_fourn_price =0;
                         $ref_supplier='';
@@ -522,11 +522,11 @@ if (empty($reshook))
                         $price = 0;
                         $qty = isset($TNomenclature_qty[$line->id][$nomenclatureI])?$TNomenclature_qty[$line->id][$nomenclatureI]:0;
                         $tva_tx = $line->tva_tx; // An other idea ?
-                        
+
                         if(!empty($TNomenclature_fournUnitPrice[$line->id][$nomenclatureI])){
                             $price = price2num($TNomenclature_fournUnitPrice[$line->id][$nomenclatureI]);
                         }
-                        
+
                         // Get subprice from product
                         if(!empty($line->fk_product)){
                             $ProductFournisseur = new ProductFournisseur($db);
@@ -538,12 +538,12 @@ if (empty($reshook))
                                 $ref_supplier= $ProductFournisseur->ref_supplier;
                             }
                         }
-                        
+
                         //récupération du prix d'achat de la produit si pas de prix fournisseur
                         /*if(empty($price) && !empty($line->pa_ht) ){
                             $price = $line->pa_ht;
                         }*/
-                        
+
                         // SEARCH in supplier order if same product exist
                         $supplierLineRowidExist = 0 ;
                         if(!empty($CommandeFournisseur->lines) && $conf->global->SOFO_ADD_QUANTITY_RATHER_THAN_CREATE_LINES)
@@ -560,11 +560,11 @@ if (empty($reshook))
                                 }
                             }
                         }
-                        
+
                         // UPDATE SUPPLIER LINE
                         if($supplierLineRowidExist>0)
                         {
-                            
+
                             $updateRes = $CommandeFournisseur->updateline(
                                 $fournLine->id,
                                 $fournLine->desc,
@@ -576,7 +576,7 @@ if (empty($reshook))
                                 $fournLine->localtax2_tx,
                                 'HT',
                                 0,
-                                $product->type, 
+                                $product->type,
                                 0, // $notrigger
                                 '',
                                 '',
@@ -585,14 +585,14 @@ if (empty($reshook))
                                 0, // $pu_ht_devise
                                 $fournLine->ref_supplier
                              );
-                            
+
                             if($updateRes>=0) // yes $CommandeFournisseur->updateline can return 0 on success
                             {
                                 // add order line in linked element
                                 $commandeFournisseurLigne = new CommandeFournisseurLigne($db);
                                 $commandeFournisseurLigne->fetch($addRes);
                                 $commandeFournisseurLigne->add_object_linked('commandedet', $line->id);
-                                
+
                                 // sauvegarde des infos pour l'affichage du resultat
                                 $TDispatchNomenclature[$line->id][$nomenclatureI] = array(
                                     'status' => 1,
@@ -613,8 +613,8 @@ if (empty($reshook))
                         else
                         {
 
-                            
-                            
+
+
                             // ADD LINE
                             $addRes = $CommandeFournisseur->addline(
                                 '',
@@ -640,19 +640,19 @@ if (empty($reshook))
                                 'commandedet', //$origin= // peut être un jour ça sera géré...
                                 $line->id //$origin_id=0 // peut être un jour ça sera géré...
                             );
-                            
-                            
-                    
-                            
-                            
+
+
+
+
+
                             if($addRes>0)
                             {
-                                
+
                                 // add order line in linked element
                                 $commandeFournisseurLigne = new CommandeFournisseurLigne($db);
                                 $commandeFournisseurLigne->fetch($addRes);
                                 $commandeFournisseurLigne->add_object_linked('commandedet', $line->id);
-                                
+
                                 // sauvegarde des infos pour l'affichage du resultat
                                 $TDispatchNomenclature[$line->id][$nomenclatureI] = array(
                                     'status' => 1,
@@ -668,31 +668,31 @@ if (empty($reshook))
                                     'msg' => $CommandeFournisseur->getNomUrl(1).' '.$langs->trans('ErrorAddSupplierLine').' : '.$commandeFournisseurLigne->error
                                 );
                             }
-                        
+
                         }
-                        
-                        
-                        
+
+
+
                     }
-                    
-                    
-                    
+
+
+
                 }
             }
-            
-	        
+
+
 	        $conf->global->SUPPLIER_ORDER_WITH_NOPRICEDEFINED = $saveconf_SUPPLIER_ORDER_WITH_NOPRICEDEFINED;
 	    }
 	    $action = 'showdispatchresult';
 	}
-	
+
 }
 
 
 /*
  * View
  */
-	
+
 $title = $langs->trans('ProductsToOrder');
 $helpurl = 'EN:Module_Stocks_En|FR:Module_Stock|';
 $helpurl .= 'ES:M&oacute;dulo_Stocks';
@@ -724,35 +724,35 @@ $productDefault = new Product($db);
 $thisUrlStart = dol_buildpath('supplierorderfromorder/dispatch_to_supplier_order.php',1);
 
 if( ($action === 'prepare' || $action == 'showdispatchresult')  && !empty($origin->lines)){
-    
+
     $origin->fetch_optionals();
     //$TlistContact = $origin->liste_contact(-1,'external',0,'SHIPPING');
-    
 
-    
+
+
     $TFournLines = array();
-    
+
     $countErrors = 0;
     foreach ( $TDispatch as $lineId => $infos)
     {
         if($infos['status'] < 0) $countErrors ++;
     }
-    
+
     if($countErrors>0)
     {
         setEventMessage('Il y a des erreurs...', 'errors');
     }
 
 
-    
+
     print '<div class="div-table-responsive">';
     print '<form id="crea_commande" name="crea_commande" action="'.$thisUrlStart.'" method="POST">';
-    
+
     print '<input type="hidden" name="from" value="'.$from.'" />';
     print '<input type="hidden" name="fromid" value="'.$fromid.'" />';
-    
+
     print '<table width="100%" class="noborder noshadow" >';
-    
+
     $totalNbCols = 6;
     print '<thead>';
     print '   <tr class="liste_titre" >';
@@ -766,7 +766,7 @@ if( ($action === 'prepare' || $action == 'showdispatchresult')  && !empty($origi
     }
     print '       <th >' . $form->textwithtooltip($langs->trans('QtyToOrder'), $langs->trans('QtyToOrderHelp'),2,1,img_help(1,'')) . '</th>';
     print '       <th class="left" >' . $langs->trans('Supplier') . '</th>';
-    
+
     if(!empty($conf->global->SOFO_USE_DELIVERY_CONTACT)){
         $totalNbCols++;
         print '       <th  >' . $form->textwithtooltip($langs->trans('Delivery'), $langs->trans('DeliveryHelp'),2,1,img_help(1,'')) . '<br/><small style="cursor:pointer;" id="emptydelivery" ><i class="fa fa-truck" ></i>Vider</small></th>';
@@ -776,31 +776,31 @@ if( ($action === 'prepare' || $action == 'showdispatchresult')  && !empty($origi
     print '       <th  style="text-align:center;" ><input id="checkToggleNomenclature" class="checkboxtoggletrigger" type="checkbox" name="togglecheckallnomenclature" value="0"   ></th>';
     print '   </tr>';
     print '</thead>';
-    
-    
+
+
     if(!empty($origin->lines)){
         print '<tbody>';
-        
-        
+
+
         $last_title_line_i = -1; // init last title i
-        
-        
-        foreach($origin->lines as $i => $line){ 
+
+
+        foreach($origin->lines as $i => $line){
 
             // do not import services
             if($line->product_type === 1)
             {
                 continue;
             }
-            
+
             $errors = 0;
             $disable = 0;
-            
+
             $line->fournUnitPrice = ''; // leave empty to use database fourn price
             $line->fournPrice = ''; // leave empty to use database fourn price * qty
             $line->fk_soc_fourn = 0; // soc id for supplier order
             $line->fk_soc_dest = 0;  // soc id for supplier order delivery contact
-            
+
             // Load Product
             if(!empty($line->fk_product))
             {
@@ -810,21 +810,21 @@ if( ($action === 'prepare' || $action == 'showdispatchresult')  && !empty($origi
                 $line->label = $product->label;
                 $product->load_stock('');
             }
-            
+
             // TODO : Detect subtotal lines without subtotal
             $line->isModSubtotalLine = 0;
             if(class_exists('TSubtotal') && TSubtotal::isModSubtotalLine($line)){
                 $line->isModSubtotalLine = 1;
-                
+
                 // Use to know line's title
                 if(TSubtotal::isTitle($line)){
                     $last_title_line_i = $i; // set last title $i
                 }elseif( TSubtotal::isSubtotal($line)){
                     $last_title_line_i = -1; // reset last title $i
                 }
-                
+
             }
-            
+
             $lineStyleColor='';
             // Add background color to line
             if(!empty($line->isModSubtotalLine))
@@ -841,44 +841,44 @@ if( ($action === 'prepare' || $action == 'showdispatchresult')  && !empty($origi
                     $lineStyleColor ='#b8ecb1';
                 }
             }
-            
+
             $lineStyle = '';
             if(!empty($lineStyleColor))
             {
                 $lineStyle .= 'background:'.$lineStyleColor.';';
             }
-            
-            
-            
+
+
+
             // START NEW LINE
             print '<tr class="objectline-row"  data-lineid="'.$line->id.'" style="'.$lineStyle.'" >';
-            
+
             // COL DESC
             print '<td class="col-desc" >';
             if(!empty($line->product)){
                 print '<strong>'. $line->product->getNomUrl(1).'</strong> ';
             }
-            
+
             if($line->isModSubtotalLine){
                 print '<strong>'. $line->label.'</strong> ';
             }
             else {
                 print empty($line->label)?$line->desc:$line->label;
             }
-            
-            
+
+
             if(!empty($TDispatch[$line->id]) &&  $TDispatch[$line->id]['status'] < 0)
             {
                 print '<p>'.$TDispatch[$line->id]['msg'].'</p>';
             }
-            
+
             print '</td>';
-            
+
             // Check if this line is allready dispatched
             $searchSupplierOrderLine = getLinkedSupplierOrdersLinesFromElementLine($line->id);
-            
-            
-            
+
+
+
             // GET NOMENCLATURE (show display nomenclature lines for print part)
             $nomenclatureViewToHtml = '';
 			$deep = 0; $maxDeep = 1; $qty = 1 ; //$line->qty
@@ -891,30 +891,30 @@ if( ($action === 'prepare' || $action == 'showdispatchresult')  && !empty($origi
 
 				$nomenclatureViewToHtml = _nomenclatureViewToHtml($line, $Tnomenclature, $param);
 			}
-            
-            
-            // 
+
+
+            //
             if(!$line->isModSubtotalLine  && empty($searchSupplierOrderLine))
             {
-                
-                
+
+
                 $line->fk_soc_dest = $origin->socid;
-                
+
                 // récupération du contact de livraison
                 if(!empty($TlistContact))
                 {
                     $select_shipping_dest_filter = $TlistContact[0]['id'];
                     $line->fk_soc_dest = $TlistContact[0]['socid'];
                 }
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
                 // QTY
                 print '<td class="center col-qtyordered"  ><strong title="'.$langs->trans('clicToReplaceQty').'" class="addvalue2target classfortooltip" style="cursor:pointer" data-value="'.$line->qty.'" data-target="#qty-'.$line->id.'"  >'.$line->qty.'</strong></td>';
-                
+
                 if (!empty($conf->stock->enabled)){
                     // STOCK REEL
                     print '<td  class="center col-realstock">';
@@ -923,7 +923,7 @@ if( ($action === 'prepare' || $action == 'showdispatchresult')  && !empty($origi
                         print $product->stock_reel;
                     }
                     print '</td>';
-                    
+
                     // STOCK THEORIQUE
                     print '<td  class="center col-theoreticalstock">';
                     if(!empty($line->fk_product) && $line->product_type == Product::TYPE_PRODUCT)
@@ -932,7 +932,7 @@ if( ($action === 'prepare' || $action == 'showdispatchresult')  && !empty($origi
                     }
                     print '</td>';
                 }
-                
+
                 if(!empty($line->fk_product))
                 {
                     $stocktheoBeforeOrder = $product->stock_theorique + $line->qty;
@@ -940,13 +940,13 @@ if( ($action === 'prepare' || $action == 'showdispatchresult')  && !empty($origi
                 else {
                     $stocktheoBeforeOrder = 0;
                 }
-                
-                
+
+
                 $qty2Order = $line->qty;
-                
+
                 if($line->product_type == Product::TYPE_PRODUCT)
                 {
-                    
+
                     if (!empty($conf->stock->enabled)){
 
                         if( $stocktheoBeforeOrder - $line->qty >= 0){
@@ -963,60 +963,60 @@ if( ($action === 'prepare' || $action == 'showdispatchresult')  && !empty($origi
                     }
 
                 }
-                
-                
+
+
                 // QTY
                 if(!empty($Tnomenclature)){
                     $qty2Order = 0;
                 }
-                
+
                 if(!empty($Tqty[$line->id])){
                     $qty2Order = $Tqty[$line->id];
                 }
-                                
+
                 print '<td class="center col-qtytoorder" >';
                 if(empty($conf->global->SOFO_DISABLE_ORDER_POSIBILITY_TO_PRODUCT_WITH_NOMENCLATURE)){
                     print '<input id="qty-'.$line->id.'" class="qtyform col-qtytoorder" data-lineid="'.$line->id.'" type="number" name="qty['.$line->id.']" value="'.$qty2Order.'" min="0"  >';
                 }
                 print '</td>';
-                
-               
-   
-                
+
+
+
+
                 /*
                  * SELECTION FOURNISSEUR
                  */
-                
+
                 print '<td class="col-fourn" >';
                 if(empty($conf->global->SOFO_DISABLE_ORDER_POSIBILITY_TO_PRODUCT_WITH_NOMENCLATURE))
                 {
-                
+
                     if(!empty($line->fk_product))
                     {
                         // get min fourn price id
                         $minFournPriceId = sofo_getFournMinPrice($line->fk_product);
-                        
-                        
+
+
                         if(!empty($Tproductfournpriceid[$line->id])){
                             $minFournPriceId = $Tproductfournpriceid[$line->id];
                         }
-                        
+
                         print $form->select_product_fourn_price($line->fk_product, 'productfournpriceid['.$line->id.']', $minFournPriceId);
-                        
+
                     }
                     else
                     {
                         // In case of a free line
-                        
+
                         print $form->select_company(GETPOST('fk_soc_fourn_'.$line->id,'int'),'fk_soc_fourn_'.$line->id, '',1,'supplier');
                         print ' &nbsp;&nbsp;&nbsp; <input class="unitPriceField" type="number" name="fournUnitPrice['.$line->id.']" value="'.price2num($line->pa_ht).'" min="0" step="any" placeholder="'.$langs->trans('UnitPrice').'" >&euro; ';
                         //print $form->selectUnits($line->fk_unit, 'units['.$line->id.']', 1);
-                        
+
                         $productDefault->fk_unit = $line->fk_unit;
                         print $productDefault->getLabelOfUnit();
                     }
                 }
-                
+
                 // Additionnal options for nomenclature
                 if(!empty($Tnomenclature))
                 {
@@ -1025,54 +1025,54 @@ if( ($action === 'prepare' || $action == 'showdispatchresult')  && !empty($origi
                         print '<div class="moreoptionblock" id="moreoption'.$line->id.'" >';
                         print '<fieldset><legend>'.$langs->trans('Nomenclature').'</legend>';
                     }
-                    
+
                     $selectFournFormName = 'force_nomenclature_fk_soc_fourn_'.$line->id;
                     $selectFournForm = $form->select_company(GETPOST($selectFournFormName,'int'),$selectFournFormName, '',1,'supplier', $forcecombo=0, array(), 0, 'minwidth100', '', '', 2);
                     print '<div>'.$selectFournForm.' '.$form->textwithtooltip( $langs->trans('ForceFourn') , $langs->trans('ForceFournHelp'),2,1,img_help(1,'')) .'</div>';
-                    
+
                     if(empty($conf->global->SOFO_DISABLE_ORDER_POSIBILITY_TO_PRODUCT_WITH_NOMENCLATURE)){
                         print '</fieldset>';
                         print '</div>';
                     }
                 }
-                
+
                 print '</td>';
-                
-                
-                
-                
+
+
+
+
                 /*
                  * SELECTION CONTACT DE LIVRAISON
                  */
                 if(!empty($conf->global->SOFO_USE_DELIVERY_CONTACT))
                 {
                     print '<td>';
-                    
+
                     if(empty($conf->global->SOFO_DISABLE_ORDER_POSIBILITY_TO_PRODUCT_WITH_NOMENCLATURE)){
                         if(isset($TShipping[$line->id])){
                             $select_shipping_dest_filter = $TShipping[$line->id];
                         }
-                        
+
                         $selecContactRes = $form->select_contacts($line->fk_soc_dest,$select_shipping_dest_filter,'shipping['.$line->id.']',1);
                         if(empty($selecContactRes))
                         {
                             $socDest = new Societe($db);
                             $socDest->fetch($line->fk_soc_dest);
-                            
+
                             print '<br/>'.$socDest->getNomUrl(1); //.' : <span class="error" >'.$langs->trans('ProductionFactoryShippingNotDefined').'</span>';
                         }
                         print '</td>';
                     }
                 }
-                
-                
+
+
                 // UNIT PRICE
                 //print '<td ><input type="number" name="fournUnitPrice['.$line->id.']" value="'.$line->fournUnitPrice.'"  required ></td>';
-                
+
 
                 // LINE PRICE
                 //print '<td ><input type="number" name="fournPrice['.$line->id.']" value="'.$line->fournPrice.'" ></td>';
-                
+
                 // CHECKBOX
                 print '<td  style="text-align:center;"  >';
                 if(!$disable)
@@ -1084,7 +1084,7 @@ if( ($action === 'prepare' || $action == 'showdispatchresult')  && !empty($origi
                     elseif(empty($qty2Order)||empty($line->fk_product)||!empty($Tnomenclature)){
                         $check = false;
                     }
-                    
+
                     if(empty($conf->global->SOFO_DISABLE_ORDER_POSIBILITY_TO_PRODUCT_WITH_NOMENCLATURE)){
                         print '<input id="linecheckbox'.$line->id.'" class="checkboxToggle" type="checkbox" '.($check?'checked':'').' name="checked['.$line->id.']" value="'.$line->id.'">';
                     }
@@ -1093,14 +1093,14 @@ if( ($action === 'prepare' || $action == 'showdispatchresult')  && !empty($origi
                 {
                     print $langs->trans('CheckErrorsBeforeInport');
                 }
-                
+
                 print '</td>';
-                
+
                 // NOMENCLATURE CHECKBOX COL
                 print '<td  style="text-align:center;"  >';
                 //print '<input class="checkboxtoggletrigger" type="checkbox" name="togglecheckallProductNomenclature" value="0"   >';
                 print '</td>';
-            
+
             }
             else {
                 print '<td colspan="7" >';
@@ -1113,46 +1113,46 @@ if( ($action === 'prepare' || $action == 'showdispatchresult')  && !empty($origi
                         $commandeFournisseurLigne = new CommandeFournisseurLigne($db);
                         $resFetchCommandeFournisseurLigne = (int) $commandeFournisseurLigne->fetch($searchSupplierOrderLineId);
                         if($resFetchCommandeFournisseurLigne > 0){
-                            
+
                             // petite opti
                             if(!in_array($commandeFournisseurLigne->fk_commande, $TAllreadyDispatchedSuppOrderLines))
                             {
-                                
+
                                 $existingFournOrder = New CommandeFournisseur($db);
                                 $existingFournOrder->fetch($commandeFournisseurLigne->fk_commande);
-                                
+
                                 print !empty($TAllreadyDispatchedSuppOrderLines)?', ':'';
-                                
+
                                 print $existingFournOrder->getNomUrl(1);
-                                
+
                                 $existingFournOrder->fetch_thirdparty();
                                 if(!empty($existingFournOrder->thirdparty))
                                 {
                                     print ' '.$existingFournOrder->thirdparty->getNomUrl(1,'supplier');
                                 }
-                                
+
                                 /*if(GETPOST('forcedeletelinked','int')){
                                  $line->deleteObjectLinked();
                                  }*/
                             }
-                            
+
                             $TAllreadyDispatchedSuppOrderLines[$commandeFournisseurLigne->id] = $commandeFournisseurLigne->fk_commande;
-                            
-                            
+
+
                         }
                     }
-                    
+
                     if(!empty($TAllreadyDispatchedSuppOrderLines))
                     {
                         print '<br/> '.$langs->trans('AllreadyDispatched'.(count($TAllreadyDispatchedSuppOrderLines)>1?'s':''));
-                        
+
                         // Display a link to show nomenclature part
                         if(!empty($nomenclatureViewToHtml))
                         {
                             print ' <small style="cursor:pointer" class="toggle-display-nomenclature-detail" data-target="'.$line->id.'" >'.$langs->trans('DisplayNomenclature').'</small>';
                         }
                     }
-                    
+
                 }
                 elseif(!$line->isModSubtotalLine && $line->product_type === 1)
                 {
@@ -1165,32 +1165,32 @@ if( ($action === 'prepare' || $action == 'showdispatchresult')  && !empty($origi
                 print '</td>';
 
             }
-            
+
             print '</tr>';
-            
-            
+
+
             // DISPLAY NOMENCLATURE LINES
             print $nomenclatureViewToHtml;
-            
-            
-            
+
+
+
         }
-        
+
         print '</tbody>';
-    } 
-    
+    }
+
     print '</table>';
-    
+
     print '<div style="clear:both; text-align: left; display:none;" ><input id="bypassjstests" type="checkbox" name="bypassjstests" value="1"> <label for="bypassjstests" >'.$langs->trans('ForceDispatch').'.</label></div>';
-    
+
     print '<div style="text-align: right;" ><button  type="submit" name="action" value="dispatch" >'.$langs->trans('Dispatch').' <i class="fa fa-arrow-right"></i></button></div>';
-    
+
     print '</form>';
     print '</div>';
-    
+
     // Inclusion du fichier script de pré-validation des formulaires
     print '<script type="text/javascript" src="'.dol_buildpath('supplierorderfromorder/js/dispatch_to_supplier_order.js.php',1).'"></script>';
-    
+
 }
 
 
@@ -1207,44 +1207,44 @@ function _nomenclatureViewToHtml($line, $TNomenclatureLines, $overrideParam = ar
 {
     global $db,$langs, $TChecked, $nomenclatureI,$form, $TDispatchNomenclature, $conf;
     global $TNomenclature_productfournpriceid, $TNomenclature_qty, $TNomenclature_fournUnitPrice;
-    
+
 
     if(empty($TNomenclatureLines)){
         return '';
     }
-    
+
     $print='';
-    
+
     $param = array(
         'colspan' => 7
         ,'searchSupplierOrderLine'=>0
     );
-    
+
     // Replace defaults param
     if(!empty($overrideParam) && is_array($overrideParam)){
         foreach($overrideParam as $k => $v){
             $param[$k] = $v;
         }
     }
-    
+
     $displayLine = '';
     if(!empty($param['searchSupplierOrderLine']))
     {
         $displayLine = 'display:none;';
     }
-    
+
     //$print.= '<tr class="nomenclature-row" data-parentlineid="'.$line->id.'" style="'.$displayLine.'" ><td colspan="'.$param['colspan'].'" ></td></tr>';
-    
+
     foreach ($TNomenclatureLines as $i => $productPart)
     {
         // FIXME : $productPart->id is empty so I use $i instead of $productPart->id
         $nomenclatureI = $line->id.'_'.$i;
-        
-        
-        
+
+
+
         $qty2Order=0;
         $disable = 0;
-        
+
         $colspan = $param['colspan'];
 
         $product =false;
@@ -1256,13 +1256,13 @@ function _nomenclatureViewToHtml($line, $TNomenclatureLines, $overrideParam = ar
                 $product =false;
             }
         }
-        
+
         if($productPart['element'] != 'workstation' && $product )
         {
-            
+
             $style = 'font-size:0.9em;color:#666;';
             $print.= '<tr class="nomenclature-row" data-parentlineid="'.$line->id.'"  style="'.$displayLine.$style.'">';
-            
+
             // DESC
             $print.= '<td class="col-desc" ><i class="fa fa-caret-right" ></i> ';
             $colspan--;
@@ -1272,7 +1272,7 @@ function _nomenclatureViewToHtml($line, $TNomenclatureLines, $overrideParam = ar
             $print.= $productPart['infos']['label'];
             if(!empty($productPart['infos']['desc'])){ $print.= ' '.$productPart['infos']['desc']; }
             $print.= '<input type="hidden" name="nomenclature_productfournproductid['.$line->id.']['.$nomenclatureI.']" value="'.$product->id.'" />';
-            
+
             if(!empty($TDispatchNomenclature[$line->id][$nomenclatureI]))
             {
                 $msgClass = 'dispatch-msg';
@@ -1280,23 +1280,23 @@ function _nomenclatureViewToHtml($line, $TNomenclatureLines, $overrideParam = ar
                 {
                     $msgClass = 'dispatch-err';
                 }
-            
+
                 $print.=  '<div class="'.$msgClass.'" >'.$TDispatchNomenclature[$line->id][$nomenclatureI]['msg'].'</div>';
             }
             $print.= '</td>';
-            
+
             // QTY
             $colspan--;
             $print.=  '<td class="center col-qtyordered" >';
             $print.=  '<strong title="'.$langs->trans('clicToReplaceQty').'" class="addvalue2target classfortooltip" style="cursor:pointer" data-value="'.$productPart['infos']['qty'].'" data-target="#qty-'.$line->id.'-n'.$nomenclatureI.'"  >'.$productPart['infos']['qty'].'</strong>';
             $print.=  '</td>';
-            
-            
+
+
             if (!empty($conf->global->SOFO_FILL_QTY_NOMENCLATURE)){
                 $qty2Order = $productPart['infos']['qty'];
             }
-            
-            
+
+
             if (!empty($conf->stock->enabled)){
 
                 // STOCK REEL
@@ -1304,28 +1304,28 @@ function _nomenclatureViewToHtml($line, $TNomenclatureLines, $overrideParam = ar
                 $print.=  '<td  class="center col-realstock">';
                 $print.=  $product->stock_reel;
                 $print.=  '</td>';
-                
+
                 // STOCK THEORIQUE
                 $colspan--;
                 $print.=  '<td  class="center col-theoreticalstock">';
                 $print.=  $product->stock_theorique;
                 $print.=  '</td>';
-               
+
             }
-            
+
             // QTY TO ORDER
             $colspan--;
-            
 
-            
+
+
             if(!empty($TNomenclature_qty[$line->id][$nomenclatureI])){
                 $qty2Order = $TNomenclature_qty[$line->id][$nomenclatureI];
             }
             $print.= '<td class="center col-qtytoorder" >';
             $print.= '<input id="qty-'.$line->id.'-n'.$nomenclatureI.'" class="qtyform-nomenclature col-qtytoorder" data-lineid="'.$line->id.'" data-nomenclature="'.$nomenclatureI.'" type="number" name="nomenclature_qty['.$line->id.']['.$nomenclatureI.']" value="'.$qty2Order.'" min="0"  >';
             $print.= '</td>';
-            
-            
+
+
             // SELECTION FOURNISSEUR
             $colspan--;
             $print.=  '<td class="col-fourn" >';
@@ -1358,19 +1358,19 @@ function _nomenclatureViewToHtml($line, $TNomenclatureLines, $overrideParam = ar
 				$print.= ' &nbsp;&nbsp;&nbsp; <input class="unitPriceField" type="number" name="nomenclature_fournUnitPrice['.$line->id.']['.$nomenclatureI.']" value="'.price2num($fournPrice).'" min="0" step="any" placeholder="'.$langs->trans('UnitPrice').'" >';
 				$print.= $product->getLabelOfUnit();
 			}
-                
-                
-                
+
+
+
 
             $print.=  '</td>';
-            
+
             // COLSPAN
             $colspan--; // FOR checkbox col
             if($colspan>0)
             {
-                $print.= '<td colspan="'.$colspan.'" ></td>'; 
+                $print.= '<td colspan="'.$colspan.'" ></td>';
             }
-            
+
             // CHECKBOX
             $print.= '<td  style="text-align:center;"  >';
             if(!$disable)
@@ -1388,26 +1388,26 @@ function _nomenclatureViewToHtml($line, $TNomenclatureLines, $overrideParam = ar
                 elseif(empty($qty2Order)){
                     $check = false;
                 }
-                
+
                 $print.=  '<input id="linecheckbox'.$nomenclatureI.'-nomenclature'.''.'" class="checkboxToggle checkboxToggle-nomenclature" type="checkbox" '.($check?'checked':'').' name="checkedNomenclature['.$line->id.']['.$nomenclatureI.']" value="'.$nomenclatureI.'">';
             }
             else
             {
                 $print.=  $langs->trans('CheckErrorsBeforeInport');
             }
-            
-            
+
+
             $print.= '</tr>';
-            
+
             // TODO HOW TO USE AND DISPLAY CHILDREN ?
             /*if(!empty($productPart['children'])){
              bcb_nomenclatureViewToHtml($productPart['children']);
              }*/
         }
-        
+
     }
-    
+
     //$print.= '<tr class="nomenclature-row" data-parentlineid="'.$line->id.'" style="'.$displayLine.'" ><td colspan="'.$param['colspan'].'" ></td></tr>';
-    
+
     return $print;
 }

--- a/lib/cbn.genorder.php
+++ b/lib/cbn.genorder.php
@@ -14,9 +14,9 @@ if ($action == 'order' && isset($_POST['valid'])) {
 
             if(GETPOST('check'.$i, 'alpha') === 'on' && (GETPOST('fourn' . $i, 'int') > 0 || GETPOST('fourn_free' . $i, 'int') > 0)) { //one line
 
-            	//echo GETPOST('tobuy_free'.$i).'<br>';
+            	//echo GETPOST('tobuy_free'.$i, 'none').'<br>';
             	//Lignes de produit
-            	if(!GETPOST('tobuy_free'.$i)){
+            	if(!GETPOST('tobuy_free'.$i, 'none')){
 	                $box = $i;
 	                $supplierpriceid = GETPOST('fourn'.$i, 'int');
 	                //get all the parameters needed to create a line
@@ -70,7 +70,7 @@ if ($action == 'order' && isset($_POST['valid'])) {
 					$qty = GETPOST('tobuy_free'.$i, 'int');
 	                $desc = GETPOST('desc'.$i, 'alpha');
 					$product_type = GETPOST('product_type'.$i, 'int');
-					$price = price2num(GETPOST('price_free'.$i));
+					$price = price2num(GETPOST('price_free'.$i, 'none'));
 					$lineid = GETPOST('lineid_free'.$i, 'int');
 					$fournid = GETPOST('fourn_free'.$i, 'int');
 					$commandeline = new OrderLine($db);
@@ -103,7 +103,7 @@ if ($action == 'order' && isset($_POST['valid'])) {
 		$nb_orders_created = 0;
         $orders = array();
         $suppliersid = array_keys($suppliers);
-		$projectid = GETPOST('projectid');
+		$projectid = GETPOST('projectid', 'int');
         foreach ($suppliers as $idsupplier => $supplier) {
 
         	$sql2 = 'SELECT rowid, ref';
@@ -138,7 +138,7 @@ if ($action == 'order' && isset($_POST['valid'])) {
 				$order->socid = $idsupplier;
 //				var_dump($obj,$order);exit;
 				if(!empty($projectid)){
-					$order->fk_project = GETPOST('projectid');
+					$order->fk_project = GETPOST('projectid', 'int');
 				}
 				// On vérifie qu'il n'existe pas déjà un lien entre la commande client et la commande fournisseur dans la table element_element.
 				// S'il n'y en a pas, on l'ajoute, sinon, on ne l'ajoute pas

--- a/ordercustomer.php
+++ b/ordercustomer.php
@@ -103,7 +103,7 @@ if (!empty($conf->categorie->enabled)) {
 	if (!isset($_REQUEST['categorie'])) {
 		$TCategories = unserialize($conf->global->SOFO_DEFAULT_PRODUCT_CATEGORY_FILTER);
 	} else {
-		$categories = GETPOST('categorie');
+		$categories = GETPOST('categorie', 'none');
 
 		if (is_array($categories)) {
 			if (in_array(-1, $categories) && count($categories) > 1) {
@@ -195,7 +195,7 @@ if (in_array($action, array('valid-propal', 'valid-order'))) {
 		$nb_orders_created = 0;
 		$orders = array();
 		$suppliersid = array_keys($suppliers);
-		$projectid = GETPOST('projectid');
+		$projectid = GETPOST('projectid', 'int');
 
 		foreach ($suppliers as $idsupplier => $supplier) {
 
@@ -227,7 +227,7 @@ if (in_array($action, array('valid-propal', 'valid-order'))) {
 				$order->socid = $idsupplier;
 
 				if (!empty($projectid)) {
-					$order->fk_project = GETPOST('projectid');
+					$order->fk_project = GETPOST('projectid', 'int');
 				}
 
 				// On vérifie qu'il n'existe pas déjà un lien entre la commande client et la commande fournisseur dans la table element_element.
@@ -246,7 +246,7 @@ if (in_array($action, array('valid-propal', 'valid-order'))) {
 
 				$order->socid = $idsupplier;
 				if (!empty($projectid)) {
-					$order->fk_project = GETPOST('projectid');
+					$order->fk_project = GETPOST('projectid', 'int');
 				}
 
 				// cond reglement, mode reglement, delivery date
@@ -505,7 +505,7 @@ if (in_array($action, array('valid-propal', 'valid-order'))) {
 $TCachedProductId =& $_SESSION['TCachedProductId'];
 if (empty($TCachedProductId))
 	$TCachedProductId = array();
-if (GETPOST('purge_cached_product') == 'yes')
+if (GETPOST('purge_cached_product', 'none') == 'yes')
 	$TCachedProductId = array();
 
 //Do we want include shared sotck to kwon what order
@@ -574,7 +574,7 @@ if ($snom) {
 
 $sql .= ' AND p.tobuy = 1';
 
-$finished = GETPOST('finished');
+$finished = GETPOST('finished', 'none');
 if ($finished != '' && $finished != '-1')
 	$sql .= ' AND p.finished = ' . $finished;
 elseif (!isset($_REQUEST['button_search_x']) && isset($conf->global->SOFO_DEFAUT_FILTER) && $conf->global->SOFO_DEFAUT_FILTER >= 0)
@@ -715,7 +715,7 @@ if ($resql || $resql2) {
 		'<input type="hidden" name="type" value="' . $type . '">' .
 		'<input type="hidden" name="linecount" value="' . ($num + $num2) . '">' .
 		'<input type="hidden" name="fk_commande" value="' . GETPOST('fk_commande', 'int') . '">' .
-		'<input type="hidden" name="show_stock_no_need" value="' . GETPOST('show_stock_no_need') . '">' .
+		'<input type="hidden" name="show_stock_no_need" value="' . GETPOST('show_stock_no_need', 'none') . '">' .
 
 		'<div style="text-align:right">
 			<a href="' . $_SERVER["PHP_SELF"] . '?' . $_SERVER["QUERY_STRING"] . '&show_stock_no_need=yes">' . $langs->trans('ShowLineEvenIfStockIsSuffisant') . '</a>';
@@ -949,7 +949,7 @@ if ($resql || $resql2) {
 	}
 
 	$liste_titre = "";
-	$liste_titre .= '<td class="liste_titre">' . $form->selectarray('finished', $statutarray, (!isset($_REQUEST['button_search_x']) && $conf->global->SOFO_DEFAUT_FILTER != -1) ? $conf->global->SOFO_DEFAUT_FILTER : GETPOST('finished'), 1) . '</td>';
+	$liste_titre .= '<td class="liste_titre">' . $form->selectarray('finished', $statutarray, (!isset($_REQUEST['button_search_x']) && $conf->global->SOFO_DEFAUT_FILTER != -1) ? $conf->global->SOFO_DEFAUT_FILTER : GETPOST('finished', 'none'), 1) . '</td>';
 
 	if (!empty($conf->categorie->enabled) && !empty($conf->global->SOFO_DISPLAY_CAT_COLUMN)) {
 		$liste_titre .= '<td class="liste_titre">';
@@ -1202,7 +1202,7 @@ if ($resql || $resql2) {
 			if ($stocktobuy < 0)
 				$stocktobuy = 0;
 
-			if ((empty($prod->type) && $stocktobuy == 0 && GETPOST('show_stock_no_need') != 'yes') || ($prod->type == 1 && $stocktobuy == 0 && GETPOST('show_stock_no_need') != 'yes' && !empty($conf->global->STOCK_SUPPORTS_SERVICES))) {
+			if ((empty($prod->type) && $stocktobuy == 0 && GETPOST('show_stock_no_need', 'none') != 'yes') || ($prod->type == 1 && $stocktobuy == 0 && GETPOST('show_stock_no_need', 'none') != 'yes' && !empty($conf->global->STOCK_SUPPORTS_SERVICES))) {
 				$i++;
 				continue;
 			}
@@ -1537,7 +1537,7 @@ function _prepareLine($i, $actionTarget = 'order')
 	}
 
 	//Lignes de produit
-	if (!GETPOST('tobuy_free' . $i)) {
+	if (!GETPOST('tobuy_free' . $i, 'none')) {
 		$box = $i;
 		$supplierpriceid = GETPOST('fourn' . $i, 'int');
 		//get all the parameters needed to create a line
@@ -1604,7 +1604,7 @@ function _prepareLine($i, $actionTarget = 'order')
 		$qty = GETPOST('tobuy_free' . $i, 'int');
 		$desc = GETPOST('desc' . $i, 'alpha');
 		$product_type = GETPOST('product_type' . $i, 'int');
-		$price = price2num(GETPOST('price_free' . $i));
+		$price = price2num(GETPOST('price_free' . $i, 'none'));
 		$lineid = GETPOST('lineid_free' . $i, 'int');
 		$fournid = GETPOST('fourn_free' . $i, 'int');
 		$commandeline = new OrderLine($db);

--- a/script/interface.php
+++ b/script/interface.php
@@ -14,7 +14,7 @@ dol_include_once('/supplierorderfromorder/class/sofo.class.php');
 dol_include_once('/core/class/html.form.class.php');
 
 
-$get = GETPOST('get');
+$get = GETPOST('get', 'none');
 
 if($get=='availability')
 {
@@ -24,19 +24,19 @@ elseif($get=='stock-details')
 {
 	_stockDetails();
 }
-    
-    
+
+
 
 function _getAvailability()
 {
 	global $db,$langs;
-	
-	
-	$qty= GETPOST('stocktobuy');
+
+
+	$qty= GETPOST('stocktobuy', 'none');
 	$fk_product= GETPOST('fk_product','int');
 	$fk_price= GETPOST('fk_price','int');
 	$fk_fourn = 0;
-	
+
 	if($fk_product)
 	{
 		$productFournisseur= new ProductFournisseur($db);
@@ -47,41 +47,41 @@ function _getAvailability()
 				$fk_fourn = $productFournisseur->fourn_id;
 			}
 		}
-		
+
 		$nb_day = (int)TSOFO::getMinAvailability($fk_product, $qty,1,$fk_fourn);
 		print ($nb_day == 0 ? $langs->trans('Unknown') : $nb_day.' '.$langs->trans('Days'));
 	}
 	exit();
 }
-    
+
 function _stockDetails()
 {
 	global $db,$langs,$conf;
 	$prod = new Product($db);
-	$prod->fetch(GETPOST('idprod'));
-	
-	
+	$prod->fetch(GETPOST('idprod', 'int'));
+
+
 	if($prod->id<=0)exit;
-	
+
 	$prod->load_stock();
-	
+
 	$r ='';
 	foreach($prod->stock_warehouse as $fk_warehouse=>$obj) {
-		
+
 		$e=new Entrepot($db);
 		$e->fetch($fk_warehouse);
 		$r .='<br />'.$e->getNomUrl(1).' x '.$obj->real;
-		
+
 	}
 	if(!empty($r)) {
 		print '<p>';
 		print '<strong>Stock physique</strong>';
 		print $r;
 		print '</p>';
-		
-		
+
+
 	}
-	
+
 	if(empty($conf->global->SOFO_USE_ONLY_OF_FOR_NEEDED_PRODUCT)) {
 		$sql = "SELECT DISTINCT c.rowid, cd.qty";
 		$sql.= " FROM ".MAIN_DB_PREFIX."commandedet as cd";
@@ -92,28 +92,28 @@ function _stockDetails()
 		$sql.= " AND c.entity = ".$conf->entity;
 		$sql.= " AND cd.fk_product = ".$prod->id;
 		$sql.= " AND c.fk_statut in (1,2)";
-		
+
 		$r ='';
 		$result =$db->query($sql);
 		while($obj = $db->fetch_object($result)) {
-			
+
 			$c=new Commande($db);
 			$c->fetch($obj->rowid);
-			
+
 			$r.='<br />'.$c->getNomUrl(1).' x '.$obj->qty.'';
-			
+
 		}
-		
+
 		if(!empty($r)) {
 			print '<p>';
 			print '<strong>Commande client</strong>';
 			print $r;
 			print '</p>';
-			
-			
+
+
 		}
-		
-		
+
+
 		$sql = "SELECT cd.qty, c.rowid";
 		$sql.= " FROM ".MAIN_DB_PREFIX."commande_fournisseurdet as cd";
 		$sql.= ", ".MAIN_DB_PREFIX."commande_fournisseur as c";
@@ -123,38 +123,38 @@ function _stockDetails()
 		$sql.= " AND c.entity = ".$conf->entity;
 		$sql.= " AND cd.fk_product = ".$prod->id;
 		$sql.= " AND c.fk_statut in (3)";
-		
+
 		$r ='';
 		$result =$db->query($sql);
 		while($obj = $db->fetch_object($result)) {
-			
+
 			$c=new CommandeFournisseur($db);
 			$c->fetch($obj->rowid);
-			
+
 			$r.='<br />'.$c->getNomUrl(1).' x '.$obj->qty.'';
-			
+
 		}
-		
+
 		if(!empty($r)) {
 			print '<p>';
 			print '<strong>Commande fournisseur</strong>';
 			print $r;
 			print '</p>';
-			
-			
+
+
 		}
-		
-		
-		
+
+
+
 	}
-	
-	
-	
-	
-	
+
+
+
+
+
 	if(!empty($conf->of->enabled)) {
-		
-		
+
+
 		define('INC_FROM_DOLIBARR', true);
 		dol_include_once('/of/config.php');
 		dol_include_once('/of/class/ordre_fabrication_asset.class.php');
@@ -166,23 +166,23 @@ function _stockDetails()
           WHERE ofe.entity=".$conf->entity." AND ofel.fk_product=".$prod->id." AND ofe.status IN ('VALID','OPEN')
           ORDER BY date_besoin ASC"
           		;
-          		
-          		
+
+
           		$PDOdb->Execute($sql);
           		$res = '';
           		while($obj = $PDOdb->Get_line()) {
           			$res.= '<br /><a href="'.dol_buildpath('/of/fiche_of.php?id='.$obj->rowid,1).'">'.img_picto('','object_list.png','',0).' '.$obj->numero.'</a> x '.($obj->qty ? $obj->qty : $obj->qty_needed );
           		}
-          		
+
           		if(!empty($res)) {
           			print '<p>';
           			print '<strong>Fabriqué par OF</strong>';
           			print $res;
           			print '</p>';
-          			
-          			
+
+
           		}
-          		
+
           		$sql="SELECT ofe.rowid, ofe.numero, ofe.date_lancement , ofe.date_besoin, ofel.qty, ofel.qty_needed
         , ofe.status, ofe.fk_user, ofe.total_cost
           FROM ".MAIN_DB_PREFIX."assetOf as ofe
@@ -190,24 +190,24 @@ function _stockDetails()
           WHERE ofe.entity=".$conf->entity." AND ofel.fk_product=".$prod->id." AND ofe.status IN ('VALID','OPEN')
           ORDER BY date_besoin ASC"
           		;
-          		
-          		
+
+
           		$PDOdb->Execute($sql);
           		$res = '';
           		while($obj = $PDOdb->Get_line()) {
           			$res.= '<br /><a href="'.dol_buildpath('/of/fiche_of.php?id='.$obj->rowid,1).'">'.img_picto('','object_list.png','',0).' '.$obj->numero.'</a> x '.($obj->qty ? $obj->qty : $obj->qty_needed );
           		}
-          		
+
           		if(!empty($res)) {
           			print '<p>';
           			print '<strong>Besoin dans OF</strong>';
           			print $res;
           			print '</p>';
-          			
-          			
+
+
           		}
 	}
-	
+
 	$sql = "SELECT DISTINCT e.rowid, ed.qty";
 	$sql.= " FROM ".MAIN_DB_PREFIX."expeditiondet as ed";
 	$sql.= " LEFT JOIN ".MAIN_DB_PREFIX."expedition as e ON (e.rowid=ed.fk_expedition)";
@@ -216,27 +216,27 @@ function _stockDetails()
 	$sql.= " AND e.entity = ".$conf->entity;
 	$sql.= " AND cd.fk_product = ".$prod->id;
 	$sql.= " AND e.fk_statut in (1)";
-	
+
 	$r ='';
 	$result =$db->query($sql);
 	//var_dump($db);
 	while($obj = $db->fetch_object($result)) {
-		
+
 		$e=new Expedition($db);
 		$e->fetch($obj->rowid);
-		
+
 		$r.='<br />'.$e->getNomUrl(1).' x '.$obj->qty.'';
-		
+
 	}
-	
-	
+
+
 	if(!empty($r)) {
 		print '<p>';
 		print '<strong>Expéditions</strong>';
 		print $r;
 		print '</p>';
-		
-		
+
+
 	}
-	
+
 }


### PR DESCRIPTION
# FIX

A partir de la v12 le paramètre check de la fonction GETPOST est alphanohtml par défaut ce qui fait que tous nos inputs ayant une balise html sont vidés.

Modification (et typage) de tous les paramètres check manquants.