### PR TITLE
NEW  : T2437 virtual products

### DIFF
--- a/admin/supplierorderfromorder_setup.php
+++ b/admin/supplierorderfromorder_setup.php
@@ -332,6 +332,19 @@ print '<input type="submit" class="button" value="'.$langs->trans("Modify").'">'
 print '</form>';
 print '</td></tr>';
 
+$var=!$var;
+print '<tr '.$bc[$var].'><td>';
+print $form->textwithpicto($langs->trans("SOFO_VIRTUAL_PRODUCTS"), $langs->trans('TooltipVirtualProduct')).'<br>';
+print '</td><td align="center" width="20">&nbsp;</td>';
+print '<td align="right" width="300">';
+print '<form method="POST" action="'.$_SERVER['PHP_SELF'].'">';
+print '<input type="hidden" name="token" value="'.$_SESSION['newtoken'].'">';
+print '<input type="hidden" name="action" value="set_SOFO_VIRTUAL_PRODUCTS">';
+print $form->selectyesno("SOFO_VIRTUAL_PRODUCTS",$conf->global->SOFO_VIRTUAL_PRODUCTS,1);
+print '<input type="submit" class="button" value="'.$langs->trans("Modify").'">';
+print '</form>';
+print '</td></tr>';
+
 if ($conf->multicompany->enabled && ! empty($conf->global->MULTICOMPANY_STOCK_SHARING_ENABLED)) {
 	$var = !$var;
 	print '<tr ' . $bc[$var] . '>';

--- a/admin/supplierorderfromorder_setup.php
+++ b/admin/supplierorderfromorder_setup.php
@@ -332,18 +332,20 @@ print '<input type="submit" class="button" value="'.$langs->trans("Modify").'">'
 print '</form>';
 print '</td></tr>';
 
-$var=!$var;
-print '<tr '.$bc[$var].'><td>';
-print $form->textwithpicto($langs->trans("SOFO_VIRTUAL_PRODUCTS"), $langs->trans('TooltipVirtualProduct')).'<br>';
-print '</td><td align="center" width="20">&nbsp;</td>';
-print '<td align="right" width="300">';
-print '<form method="POST" action="'.$_SERVER['PHP_SELF'].'">';
-print '<input type="hidden" name="token" value="'.$_SESSION['newtoken'].'">';
-print '<input type="hidden" name="action" value="set_SOFO_VIRTUAL_PRODUCTS">';
-print $form->selectyesno("SOFO_VIRTUAL_PRODUCTS",$conf->global->SOFO_VIRTUAL_PRODUCTS,1);
-print '<input type="submit" class="button" value="'.$langs->trans("Modify").'">';
-print '</form>';
-print '</td></tr>';
+if($conf->global->PRODUIT_SOUSPRODUITS) {
+	$var = !$var;
+	print '<tr ' . $bc[$var] . '>';
+	print '<td>' . $langs->trans('SOFO_VIRTUAL_PRODUCTS') . '</td>';
+	print '<td align="center" width="20">&nbsp;</td>';
+	print '<td align="right" width="300">';
+	print '<form method="POST" action="' . $_SERVER['PHP_SELF'] . '">';
+	print '<input type="hidden" name="token" value="' . $_SESSION['newtoken'] . '">';
+	print '<input type="hidden" name="action" value="set_SOFO_VIRTUAL_PRODUCTS">';
+	print $form->selectyesno("SOFO_VIRTUAL_PRODUCTS", $conf->global->SOFO_VIRTUAL_PRODUCTS, 1);
+	print '<input type="submit" class="button" value="' . $langs->trans("Modify") . '">';
+	print '</form>';
+	print '</td></tr>';
+}
 
 if ($conf->multicompany->enabled && ! empty($conf->global->MULTICOMPANY_STOCK_SHARING_ENABLED)) {
 	$var = !$var;

--- a/core/modules/modSupplierorderfromorder.class.php
+++ b/core/modules/modSupplierorderfromorder.class.php
@@ -62,7 +62,7 @@ class modSupplierorderfromorder extends DolibarrModules
         // (where XXX is value of numeric property 'numero' of module)
         $this->description = "Module commande fournisseur à partir d'une commande client";
         // Possible values for version are: 'development', 'experimental' or version
-        $this->version = '1.6.5';
+        $this->version = '2.0.0';
         // Key used in llx_const table to save module status enabled/disabled
         // (where MYMODULE is value of property name of module in uppercase)
         $this->const_name = 'MAIN_MODULE_' . strtoupper($this->name);

--- a/langs/fr_FR/supplierorderfromorder.lang
+++ b/langs/fr_FR/supplierorderfromorder.lang
@@ -74,4 +74,3 @@ SOFO_ADD_QUANTITY_RATHER_THAN_CREATE_LINES=Privilègier l'ajout de quantité à 
 SOFO_PRESELECT_SUPPLIER_PRICE_FROM_LINE_BUY_PRICE=Présélectionner par défaut les prix fournisseur égaux au prix d'achat renseigné sur la ligne de commande client d'origine (nécessite le module Marges)
 SOFO_CHECK_STOCK_ON_SHARED_STOCK=Avec le module multicompany vous avez partagé la visibilité des entrepots/stocks. Voulez vous que les commande fournisseur depuis les commandes clients prennent en compte les niveaux de stock partagé ou non ?
 SOFO_VIRTUAL_PRODUCTS=Gestion des produits virtuels par le module
-TooltipVirtualProduct=Les produits virtuels dans la "configuration des modules Produits et Services" doivent activés

--- a/langs/fr_FR/supplierorderfromorder.lang
+++ b/langs/fr_FR/supplierorderfromorder.lang
@@ -73,3 +73,5 @@ ParametersNeedSOFO_USE_NOMENCLATURE=Paramètres : l'onglet "Composants à comman
 SOFO_ADD_QUANTITY_RATHER_THAN_CREATE_LINES=Privilègier l'ajout de quantité à une ligne de commande fournisseur au lieu d'ajouter une ligne pour chaque ligne de commande client
 SOFO_PRESELECT_SUPPLIER_PRICE_FROM_LINE_BUY_PRICE=Présélectionner par défaut les prix fournisseur égaux au prix d'achat renseigné sur la ligne de commande client d'origine (nécessite le module Marges)
 SOFO_CHECK_STOCK_ON_SHARED_STOCK=Avec le module multicompany vous avez partagé la visibilité des entrepots/stocks. Voulez vous que les commande fournisseur depuis les commandes clients prennent en compte les niveaux de stock partagé ou non ?
+SOFO_VIRTUAL_PRODUCTS=Gestion des produits virtuels par le module
+TooltipVirtualProduct=Les produits virtuels dans la "configuration des modules Produits et Services" doivent activés

--- a/ordercustomer.php
+++ b/ordercustomer.php
@@ -706,6 +706,56 @@ if ($resql || $resql2) {
 
 		}
 	}
+
+	$TObjs = array();
+
+	while ($i < min($num, $limit)) {
+		$objp = $db->fetch_object($resql);
+
+		array_push($TObjs, $objp);
+
+		$product = new Product($db);
+		$product->fetch($objp->rowid);
+
+
+		$product->get_sousproduits_arbo();
+		$prods_arbo = $product->get_arbo_each_prod();
+
+		//TODO : donner un numero de niveau à chaque produits dans TProds pour donner une indentation + tester car veut pas ccréer de commande fournisseur...
+
+
+		if(!empty($prods_arbo)) {
+
+			foreach ($prods_arbo as $key => $value) {
+
+				$objsp = new stdClass();
+
+				$sousproduit = new Product($db);
+				$sousproduit->fetch($value['id']);
+
+				$objsp->rowid = $sousproduit->id;
+				$objsp->ref = $sousproduit->ref;
+				$objsp->label = $sousproduit->label;
+				$objsp->price = $sousproduit->price;
+				$objsp->price_ttc = $sousproduit->price_ttc;
+				$objsp->price_base_type = $sousproduit->price_base_type;
+				$objsp->fk_product_type = $sousproduit->type;
+				$objsp->datem = $sousproduit->date_modification;
+				$objsp->duration = $sousproduit->duration_value;
+				$objsp->tobuy = $sousproduit->status_buy;
+				$objsp->seuil_stock_alert = $sousproduit->seuil_stock_alerte;
+				$objsp->finished = $sousproduit->finished;
+				$objsp->fk_parent = $value['id_parent'];
+
+				array_push($TObjs, $objsp);
+
+			}
+
+		}
+
+		$i++;
+	}
+
 	print'</div>';
 	print '<form action="' . $_SERVER['PHP_SELF'] . '?id=' . $_REQUEST['id'] . '&projectid=' . $_REQUEST['projectid'] . '" method="post" name="formulaire">' .
 		'<input type="hidden" name="id" value="' . $_REQUEST['id'] . '">' .
@@ -986,9 +1036,8 @@ if ($resql || $resql2) {
 	}
 
 	$TSupplier = array();
-	while ($i < min($num, $limit)) {
-		$objp = $db->fetch_object($resql);
-		//if($objp->rowid == 4666) { var_dump($objp); }
+
+	foreach($TObjs as $objp){
 
 		if ($conf->global->SOFO_DISPLAY_SERVICES || $objp->fk_product_type == 0) {
 
@@ -1333,8 +1382,6 @@ if ($resql || $resql2) {
 		}
 
 		//	if($prod->ref=='A0000753') exit;
-
-		$i++;
 	}
 
 	//Lignes libre

--- a/ordercustomer.php
+++ b/ordercustomer.php
@@ -667,7 +667,7 @@ if ($resql || $resql2) {
 
 			if (!empty($prods_arbo)) {
 
-				$TProductToHaveQtys = array();        //tableau des dernières quantités nécessaires par niveau pour la commande
+				$TProductToHaveQtys = array();        //tableau des dernières quantités à commander par niveau
 
 				foreach ($prods_arbo as $key => $value) {
 
@@ -703,12 +703,13 @@ if ($resql || $resql2) {
 					$objsp->seuil_stock_alert = $sousproduit->seuil_stock_alerte;
 					$objsp->finished = $sousproduit->finished;
 					$objsp->stock_physique = $sousproduit->stock_reel;
-					$objsp->desiredstock = $qtyParentToHave * $value['nb'];        //le stock désiré est égal au stock du produit parent à avoir * le nombre de sous-produit nécessaire pour le produit parent
+					$objsp->qty =  $qtyParentToHave * $value['nb'];			//qty du produit = quantité du produit parent commandé * nombre du sous-produit nécessaire pour le produit parent
+					$objsp->desiredstock = $sousproduit->desiredstock;
 					$objsp->fk_parent = $value['id_parent'];
 					$objsp->level = $value['level'];
 
-					//Sauvegarde du stock désiré
-					$TProductToHaveQtys[$value['level']] = $objsp->desiredstock;
+					//Sauvegarde du dernier stock commandé pour le niveau du sous-produit
+					$TProductToHaveQtys[$value['level']] = $objsp->qty;
 
 					//ajout du sous-produit dans le tableau
 					array_push($TProducts, $objsp);
@@ -1123,6 +1124,8 @@ if ($resql || $resql2) {
 							dol_print_error($db, $prod->error);
 						}
 						$stock_commande_client = $prod->stats_commande['qty'];
+						//si c'est un sous-produit, on ajoute la quantité à commander calculée plus tôt en plus
+						if(!empty($objp->level)) $stock_commande_client = $stock_commande_client + $objp->qty;
 					} else {
 						$stock_commande_client = 0;
 					}

--- a/ordercustomer.php
+++ b/ordercustomer.php
@@ -651,6 +651,7 @@ if ($resql || $resql2) {
 	while ($i < min($num, $limit)) {
 		$objp = $db->fetch_object($resql);
 
+
 		array_push($TObjs, $objp);
 
 		$product = new Product($db);
@@ -663,6 +664,8 @@ if ($resql || $resql2) {
 		if(!empty($prods_arbo)) {
 
 			foreach ($prods_arbo as $key => $value) {
+
+				if(empty($key)) $qtytohavesave = $objp->qty;
 
 				$objsp = new stdClass();
 
@@ -681,8 +684,12 @@ if ($resql || $resql2) {
 				$objsp->tobuy = $sousproduit->status_buy;
 				$objsp->seuil_stock_alert = $sousproduit->seuil_stock_alerte;
 				$objsp->finished = $sousproduit->finished;
+				$objsp->stock_physique = $sousproduit->stock_reel;
+				$objsp->desiredstock = intval($qtytohavesave) * $value['nb'];
 				$objsp->fk_parent = $value['id_parent'];
 				$objsp->level = $value['level'];
+
+				$qtytohavesave = $objsp->desiredstock;
 
 				array_push($TObjs, $objsp);
 

--- a/ordercustomer.php
+++ b/ordercustomer.php
@@ -188,7 +188,6 @@ if (in_array($action, array('valid-propal', 'valid-order'))) {
 
 		}
 
-
 		//we now know how many orders we need and what lines they have
 		$i = 0;
 		$id = 0;
@@ -715,10 +714,10 @@ if ($resql || $resql2) {
 			}
 
 		}
-
 		$i++;
 	}
 
+	$i = 0;
 	$num = count($TProducts);
 	$num2 = $db->num_rows($resql2);
 

--- a/ordercustomer.php
+++ b/ordercustomer.php
@@ -1294,9 +1294,15 @@ if ($resql || $resql2) {
 
 			$help_stock .= ', ' . $langs->trans('DesiredStock') . ' : ' . (float)$objp->desiredstock;
 
-
-			if ($stocktobuy < 0)
+			if ($stocktobuy < 0) {
 				$stocktobuy = 0;
+				$objnottobuy = $objp->rowid;
+			}
+
+			//si le produit parent n'a pas besoin d'être commandé, alors les produits fils non plus
+			if($objnottobuy == $objp->fk_parent && !empty($objnottobuy) && !empty($objp->fk_parent)) {
+				$stocktobuy = 0;
+			}
 
 			if ((empty($prod->type) && $stocktobuy == 0 && GETPOST('show_stock_no_need', 'none') != 'yes') || ($prod->type == 1 && $stocktobuy == 0 && GETPOST('show_stock_no_need', 'none') != 'yes' && !empty($conf->global->STOCK_SUPPORTS_SERVICES))) {
 				$i++;


### PR DESCRIPTION
# NEW  Gestion des produits virtuels

**Passage en v2**

Lors du passage d'une commande fournisseur depuis une commande client, si la commande client possède des produits composés de produits virtuels, ces composants virtuels seront proposés dans la liste des produits (écran intermédiaire du module "supplierorderfromorder/ordercustomer.php") à commander auprès des fournisseurs. Une indentation ou une fleche doit permettre de différencier les produits parents des produits virtuels qui les composent.