### PR TITLE
FIX 2.0.1 - warning when clicking create supplier order button

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,14 @@
+# ChangeLog
+
+## [Unreleased]
+- FIX warning when clicking “Create Supplier Order” - 2.0.1 - *23/04/2021*
+
+## 2.0
+- No changelog up to this point
+
+## 1.6
+- No changelog up to this point
+
+## 1.0
+- No changelog up to this point
+

--- a/core/modules/modSupplierorderfromorder.class.php
+++ b/core/modules/modSupplierorderfromorder.class.php
@@ -62,7 +62,7 @@ class modSupplierorderfromorder extends DolibarrModules
         // (where XXX is value of numeric property 'numero' of module)
         $this->description = "Module commande fournisseur à partir d'une commande client";
         // Possible values for version are: 'development', 'experimental' or version
-        $this->version = '2.0.0';
+        $this->version = '2.0.1';
         // Key used in llx_const table to save module status enabled/disabled
         // (where MYMODULE is value of property name of module in uppercase)
         $this->const_name = 'MAIN_MODULE_' . strtoupper($this->name);

--- a/ordercustomer.php
+++ b/ordercustomer.php
@@ -724,7 +724,7 @@ if ($resql || $resql2) {
 
 	$i = 0;
 	$num = count($TProducts);
-	$num2 = $db->num_rows($resql2);
+	$num2 = $resql2 ? $db->num_rows($resql2) : 0;
 
 	$helpurl = 'EN:Module_Stocks_En|FR:Module_Stock|';
 	$helpurl .= 'ES:M&oacute;dulo_Stocks';


### PR DESCRIPTION
# FIX
## [Unreleased]
- FIX warning when clicking “Create Supplier Order” - 2.0.1 - *23/04/2021*
