### PR TITLE
FIX : Nouvelle conf pour prendre en compte ou non les commandes fournisseurs approuvée pour les stocks virtuels 

### DIFF
--- a/admin/supplierorderfromorder_setup.php
+++ b/admin/supplierorderfromorder_setup.php
@@ -332,6 +332,19 @@ print '<input type="submit" class="button" value="'.$langs->trans("Modify").'">'
 print '</form>';
 print '</td></tr>';
 
+$var=!$var;
+print '<tr '.$bc[$var].'>';
+print '<td>'.$langs->trans('TAKE_CARE_OF_APPROUVED_SUPPLIER_ORDER_FOR_VIRTUAL_STOCK').'</td>';
+print '<td align="center" width="20">&nbsp;</td>';
+print '<td align="right" width="300">';
+print '<form method="POST" action="'.$_SERVER['PHP_SELF'].'">';
+print '<input type="hidden" name="token" value="'.$_SESSION['newtoken'].'">';
+print '<input type="hidden" name="action" value="set_TAKE_CARE_OF_APPROUVED_SUPPLIER_ORDER_FOR_VIRTUAL_STOCK">';
+print $form->selectyesno('TAKE_CARE_OF_APPROUVED_SUPPLIER_ORDER_FOR_VIRTUAL_STOCK', $conf->global->TAKE_CARE_OF_APPROUVED_SUPPLIER_ORDER_FOR_VIRTUAL_STOCK,1);
+print '<input type="submit" class="button" value="'.$langs->trans("Modify").'">';
+print '</form>';
+print '</td></tr>';
+
 if ($conf->multicompany->enabled && ! empty($conf->global->MULTICOMPANY_STOCK_SHARING_ENABLED)) {
 	$var = !$var;
 	print '<tr ' . $bc[$var] . '>';

--- a/langs/fr_FR/supplierorderfromorder.lang
+++ b/langs/fr_FR/supplierorderfromorder.lang
@@ -73,3 +73,4 @@ ParametersNeedSOFO_USE_NOMENCLATURE=Paramètres : l'onglet "Composants à comman
 SOFO_ADD_QUANTITY_RATHER_THAN_CREATE_LINES=Privilègier l'ajout de quantité à une ligne de commande fournisseur au lieu d'ajouter une ligne pour chaque ligne de commande client
 SOFO_PRESELECT_SUPPLIER_PRICE_FROM_LINE_BUY_PRICE=Présélectionner par défaut les prix fournisseur égaux au prix d'achat renseigné sur la ligne de commande client d'origine (nécessite le module Marges)
 SOFO_CHECK_STOCK_ON_SHARED_STOCK=Avec le module multicompany vous avez partagé la visibilité des entrepots/stocks. Voulez vous que les commande fournisseur depuis les commandes clients prennent en compte les niveaux de stock partagé ou non ?
+TAKE_CARE_OF_APPROUVED_SUPPLIER_ORDER_FOR_VIRTUAL_STOCK=Prendre en compte les commandes fourinsseurs approuvées pour le calcul du stock virtuel

--- a/ordercustomer.php
+++ b/ordercustomer.php
@@ -1049,7 +1049,12 @@ if ($resql || $resql2) {
 					}
 
 					if (!$conf->global->STOCK_CALCULATE_ON_SUPPLIER_VALIDATE_ORDER || $conf->global->SOFO_USE_VIRTUAL_ORDER_STOCK) {
-						$result = $prod->load_stats_commande_fournisseur(0, '3,4');
+						if ($conf->global->TAKE_CARE_OF_APPROUVED_SUPPLIER_ORDER_FOR_VIRTUAL_STOCK)
+						{
+							$result = $prod->load_stats_commande_fournisseur(0, '1,2,3,4');
+						} else {
+							$result = $prod->load_stats_commande_fournisseur(0, '3,4');
+						}
 						if ($result < 0) {
 							dol_print_error($db, $prod->error);
 						}


### PR DESCRIPTION
/!\ NE PAS MERGER /!\
En discussion avec Eldy pour changer le standard, dans le cas ou la PR standard serait acceptée, ce dev deviendrait obsolète.

FIX : Nouvelle conf pour prendre en compte ou non les commandes fournisseurs approuvée pour les stocks virtuels 

Possibilité de choisir, si oui ou non, les commandes fournisseurs au statut "Approuvées" sont prise en compte pour le calcul de stock 