### PR TITLE
PULLUP - FIX : Nouvelle conf pour prendre en compte ou non les commandes fournisseurs approuvée pour les stocks virtuels

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 ## [Unreleased]
+- FIX : Add conf to take card of aproved supplier orders for virtual stocks - 2.0.2 - *28/04/2021*
 - FIX warning when clicking “Create Supplier Order” - 2.0.1 - *23/04/2021*
 
 ## 2.0

--- a/admin/supplierorderfromorder_setup.php
+++ b/admin/supplierorderfromorder_setup.php
@@ -332,6 +332,19 @@ print '<input type="submit" class="button" value="'.$langs->trans("Modify").'">'
 print '</form>';
 print '</td></tr>';
 
+$var=!$var;
+print '<tr '.$bc[$var].'>';
+print '<td>'.$langs->trans('TAKE_CARE_OF_APPROUVED_SUPPLIER_ORDER_FOR_VIRTUAL_STOCK').'</td>';
+print '<td align="center" width="20">&nbsp;</td>';
+print '<td align="right" width="300">';
+print '<form method="POST" action="'.$_SERVER['PHP_SELF'].'">';
+print '<input type="hidden" name="token" value="'.$_SESSION['newtoken'].'">';
+print '<input type="hidden" name="action" value="set_TAKE_CARE_OF_APPROUVED_SUPPLIER_ORDER_FOR_VIRTUAL_STOCK">';
+print $form->selectyesno('TAKE_CARE_OF_APPROUVED_SUPPLIER_ORDER_FOR_VIRTUAL_STOCK', $conf->global->TAKE_CARE_OF_APPROUVED_SUPPLIER_ORDER_FOR_VIRTUAL_STOCK,1);
+print '<input type="submit" class="button" value="'.$langs->trans("Modify").'">';
+print '</form>';
+print '</td></tr>';
+
 if($conf->global->PRODUIT_SOUSPRODUITS) {
 	$var = !$var;
 	print '<tr ' . $bc[$var] . '>';

--- a/core/modules/modSupplierorderfromorder.class.php
+++ b/core/modules/modSupplierorderfromorder.class.php
@@ -62,7 +62,7 @@ class modSupplierorderfromorder extends DolibarrModules
         // (where XXX is value of numeric property 'numero' of module)
         $this->description = "Module commande fournisseur à partir d'une commande client";
         // Possible values for version are: 'development', 'experimental' or version
-        $this->version = '2.0.1';
+        $this->version = '2.0.2';
         // Key used in llx_const table to save module status enabled/disabled
         // (where MYMODULE is value of property name of module in uppercase)
         $this->const_name = 'MAIN_MODULE_' . strtoupper($this->name);

--- a/langs/fr_FR/supplierorderfromorder.lang
+++ b/langs/fr_FR/supplierorderfromorder.lang
@@ -74,3 +74,4 @@ SOFO_ADD_QUANTITY_RATHER_THAN_CREATE_LINES=Privilègier l'ajout de quantité à 
 SOFO_PRESELECT_SUPPLIER_PRICE_FROM_LINE_BUY_PRICE=Présélectionner par défaut les prix fournisseur égaux au prix d'achat renseigné sur la ligne de commande client d'origine (nécessite le module Marges)
 SOFO_CHECK_STOCK_ON_SHARED_STOCK=Avec le module multicompany vous avez partagé la visibilité des entrepots/stocks. Voulez vous que les commande fournisseur depuis les commandes clients prennent en compte les niveaux de stock partagé ou non ?
 SOFO_VIRTUAL_PRODUCTS=Gestion des produits virtuels par le module
+TAKE_CARE_OF_APPROUVED_SUPPLIER_ORDER_FOR_VIRTUAL_STOCK=Prendre en compte les commandes fourinsseurs approuvées pour le calcul du stock virtuel

--- a/ordercustomer.php
+++ b/ordercustomer.php
@@ -65,7 +65,7 @@ if ((float)DOL_VERSION >= 3.5) {
 if ($user->societe_id) {
 	$socid = $user->societe_id;
 }
-$result = restrictedArea($user, 'produit&supplierorderfromorder');
+$result = restrictedArea($user, 'produit|service&supplierorderfromorder');
 
 //checks if a product has been ordered
 
@@ -1131,7 +1131,12 @@ if ($resql || $resql2) {
 					}
 
 					if (!$conf->global->STOCK_CALCULATE_ON_SUPPLIER_VALIDATE_ORDER || $conf->global->SOFO_USE_VIRTUAL_ORDER_STOCK) {
-						$result = $prod->load_stats_commande_fournisseur(0, '3,4');
+						if ($conf->global->TAKE_CARE_OF_APPROUVED_SUPPLIER_ORDER_FOR_VIRTUAL_STOCK)
+						{
+							$result = $prod->load_stats_commande_fournisseur(0, '1,2,3,4');
+						} else {
+							$result = $prod->load_stats_commande_fournisseur(0, '3,4');
+						}
 						if ($result < 0) {
 							dol_print_error($db, $prod->error);
 						}


### PR DESCRIPTION
/!\ NE PAS MERGER /!
En discussion avec Eldy pour changer le standard, dans le cas ou la PR standard serait acceptée, ce dev deviendrait obsolète.

FIX : Nouvelle conf pour prendre en compte ou non les commandes fournisseurs approuvée pour les stocks virtuels

Possibilité de choisir, si oui ou non, les commandes fournisseurs au statut "Approuvées" sont prise en compte pour le calcul de stock