### PR TITLE
FIX : Status des commandes fournisseurs pris en compte

### DIFF
--- a/admin/supplierorderfromorder_setup.php
+++ b/admin/supplierorderfromorder_setup.php
@@ -332,19 +332,6 @@ print '<input type="submit" class="button" value="'.$langs->trans("Modify").'">'
 print '</form>';
 print '</td></tr>';
 
-$var=!$var;
-print '<tr '.$bc[$var].'>';
-print '<td>'.$langs->trans('TAKE_CARE_OF_APPROUVED_SUPPLIER_ORDER_FOR_VIRTUAL_STOCK').'</td>';
-print '<td align="center" width="20">&nbsp;</td>';
-print '<td align="right" width="300">';
-print '<form method="POST" action="'.$_SERVER['PHP_SELF'].'">';
-print '<input type="hidden" name="token" value="'.$_SESSION['newtoken'].'">';
-print '<input type="hidden" name="action" value="set_TAKE_CARE_OF_APPROUVED_SUPPLIER_ORDER_FOR_VIRTUAL_STOCK">';
-print $form->selectyesno('TAKE_CARE_OF_APPROUVED_SUPPLIER_ORDER_FOR_VIRTUAL_STOCK', $conf->global->TAKE_CARE_OF_APPROUVED_SUPPLIER_ORDER_FOR_VIRTUAL_STOCK,1);
-print '<input type="submit" class="button" value="'.$langs->trans("Modify").'">';
-print '</form>';
-print '</td></tr>';
-
 if ($conf->multicompany->enabled && ! empty($conf->global->MULTICOMPANY_STOCK_SHARING_ENABLED)) {
 	$var = !$var;
 	print '<tr ' . $bc[$var] . '>';

--- a/langs/fr_FR/supplierorderfromorder.lang
+++ b/langs/fr_FR/supplierorderfromorder.lang
@@ -73,4 +73,3 @@ ParametersNeedSOFO_USE_NOMENCLATURE=Paramètres : l'onglet "Composants à comman
 SOFO_ADD_QUANTITY_RATHER_THAN_CREATE_LINES=Privilègier l'ajout de quantité à une ligne de commande fournisseur au lieu d'ajouter une ligne pour chaque ligne de commande client
 SOFO_PRESELECT_SUPPLIER_PRICE_FROM_LINE_BUY_PRICE=Présélectionner par défaut les prix fournisseur égaux au prix d'achat renseigné sur la ligne de commande client d'origine (nécessite le module Marges)
 SOFO_CHECK_STOCK_ON_SHARED_STOCK=Avec le module multicompany vous avez partagé la visibilité des entrepots/stocks. Voulez vous que les commande fournisseur depuis les commandes clients prennent en compte les niveaux de stock partagé ou non ?
-TAKE_CARE_OF_APPROUVED_SUPPLIER_ORDER_FOR_VIRTUAL_STOCK=Prendre en compte les commandes fourinsseurs approuvées pour le calcul du stock virtuel

--- a/ordercustomer.php
+++ b/ordercustomer.php
@@ -1049,11 +1049,10 @@ if ($resql || $resql2) {
 					}
 
 					if (!$conf->global->STOCK_CALCULATE_ON_SUPPLIER_VALIDATE_ORDER || $conf->global->SOFO_USE_VIRTUAL_ORDER_STOCK) {
-						if ($conf->global->TAKE_CARE_OF_APPROUVED_SUPPLIER_ORDER_FOR_VIRTUAL_STOCK)
-						{
-							$result = $prod->load_stats_commande_fournisseur(0, '1,2,3,4');
+						if (!empty($conf->global->SUPPLIER_ORDER_STATUS_FOR_VIRTUAL_STOCK)){
+							$result=$prod->load_stats_commande_fournisseur(0, $conf->global->SUPPLIER_ORDER_STATUS_FOR_VIRTUAL_STOCK, 1);
 						} else {
-							$result = $prod->load_stats_commande_fournisseur(0, '3,4');
+							$result=$prod->load_stats_commande_fournisseur(0, '1,2,3,4', 1);
 						}
 						if ($result < 0) {
 							dol_print_error($db, $prod->error);


### PR DESCRIPTION
### FIX : Status des commandes fournisseurs pris en compte

Suite à un merge qui n'aurait pas dû être fait : suppression du code de l'ancien dev

Ajout d'une conf permettant de choisir les statuts qui seront pris en compte pour les commandes fournisseurs lors du calcul du stock virtuel (même procédé, même conf dans le standard)
Uniformisations de notre méthode de calcul avec le standard