### PR TITLE
PULLUP - FIX : Status des commandes fournisseurs pris en compte

### DIFF
--- a/ordercustomer.php
+++ b/ordercustomer.php
@@ -65,7 +65,7 @@ if ((float)DOL_VERSION >= 3.5) {
 if ($user->societe_id) {
 	$socid = $user->societe_id;
 }
-$result = restrictedArea($user, 'produit&supplierorderfromorder');
+$result = restrictedArea($user, 'produit|service&supplierorderfromorder');
 
 //checks if a product has been ordered
 
@@ -1049,7 +1049,11 @@ if ($resql || $resql2) {
 					}
 
 					if (!$conf->global->STOCK_CALCULATE_ON_SUPPLIER_VALIDATE_ORDER || $conf->global->SOFO_USE_VIRTUAL_ORDER_STOCK) {
-						$result = $prod->load_stats_commande_fournisseur(0, '3,4');
+						if (!empty($conf->global->SUPPLIER_ORDER_STATUS_FOR_VIRTUAL_STOCK)){
+							$result=$prod->load_stats_commande_fournisseur(0, $conf->global->SUPPLIER_ORDER_STATUS_FOR_VIRTUAL_STOCK, 1);
+						} else {
+							$result=$prod->load_stats_commande_fournisseur(0, '1,2,3,4', 1);
+						}
 						if ($result < 0) {
 							dol_print_error($db, $prod->error);
 						}


### PR DESCRIPTION
### FIX : Status des commandes fournisseurs pris en compte
Suite à un merge qui n'aurait pas dû être fait : suppression du code de l'ancien dev

Ajout d'une conf permettant de choisir les statuts qui seront pris en compte pour les commandes fournisseurs lors du calcul du stock virtuel (même procédé, même conf dans le standard)
Uniformisations de notre méthode de calcul avec le standard