### PR TITLE
PULLUP Main : FIX DA020591 Stock to buy error

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@
 
 ## 2.0
 
+- FIX: DA020591 : Erreur de calcul sur la qté à commander sur écran de réappro lorsque plusieurs fois le même produit dans la même commande + FIX informations infobulle - 2.0.4 - *02/07/2021*
 - FIX: v14 compatibility - NOCSRFCHECK + setDateLivraison - 2.0.3 - *29/06/2021*
 - FIX: Add conf to take card of aproved supplier orders for virtual stocks - 2.0.2 - *28/04/2021*
 - FIX: Compatibility V13 - add token renowal - 2.0.2 - *17.05.2021*

--- a/core/modules/modSupplierorderfromorder.class.php
+++ b/core/modules/modSupplierorderfromorder.class.php
@@ -63,7 +63,7 @@ class modSupplierorderfromorder extends DolibarrModules
         // (where XXX is value of numeric property 'numero' of module)
         $this->description = "Module commande fournisseur à partir d'une commande client";
         // Possible values for version are: 'development', 'experimental' or version
-        $this->version = '2.0.3';
+        $this->version = '2.0.4';
         // Key used in llx_const table to save module status enabled/disabled
         // (where MYMODULE is value of property name of module in uppercase)
         $this->const_name = 'MAIN_MODULE_' . strtoupper($this->name);

--- a/ordercustomer.php
+++ b/ordercustomer.php
@@ -1071,8 +1071,13 @@ if ($resql || $resql2) {
 	}
 
 	$TSupplier = array();
+	$TProductIDAlreadyChecked = array();
 
 	foreach($TProducts as $objp){
+
+		// Cas où on a plusieurs fois le même produit dans la même commande : dédoublonnage
+		if(in_array($objp->rowid, $TProductIDAlreadyChecked)) continue;
+		else $TProductIDAlreadyChecked[$objp->rowid] = $objp->rowid;
 
 		if ($conf->global->SOFO_DISPLAY_SERVICES || $objp->fk_product_type == 0) {
 
@@ -1261,7 +1266,6 @@ if ($resql || $resql2) {
 
 
 			$stocktobuy = $objp->desiredstock - $stock;
-
 
 
 			/*			if($stocktobuy<=0 && $prod->ref!='A0000753') {

--- a/script/interface.php
+++ b/script/interface.php
@@ -95,6 +95,7 @@ function _stockDetails()
 		$sql.= " AND c.entity = ".$conf->entity;
 		$sql.= " AND cd.fk_product = ".$prod->id;
 		$sql.= " AND c.fk_statut in (1,2)";
+		$sql.= " GROUP BY c.rowid";
 
 		$r ='';
 		$result =$db->query($sql);


### PR DESCRIPTION
# FIX

cf. DA020591
PR d'origine : https://github.com/ATM-Consulting/dolibarr_module_supplierorderfromorder/pull/65

- Erreur de calcul sur la quantité à commander sur écran de réapprovisionnement lorsque le même produit est présent plusieurs fois dans la même commande
- FIX informations infobulle sur écran de réapprovisionnement