### PR TITLE
Changement dans lib de $price 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ## 2.3
+FIX : changement du calcul de ligne pour prendre en compte le prix unitaire de la nomenclature  - *17/03/2022)* - 2.3.3  
+- FIX : change params passed to find_min_price_product_fournisseur ($productid instaed of $line->fk_product) - 2.3.0 - *30/09/2021*
 - FIX : change params passed to find_min_price_product_fournisseur ($productid instaed of $line->fk_product) - 2.3.2 - 06/01/2022
 - FIX : change SQL query aliases for list: `p` is now `prod` - 2.3.1 - 01/10/2021
 - New - add doAction hook 2.3.0 - *30/09/2021*

--- a/core/modules/modSupplierorderfromorder.class.php
+++ b/core/modules/modSupplierorderfromorder.class.php
@@ -63,7 +63,7 @@ class modSupplierorderfromorder extends DolibarrModules
         // (where XXX is value of numeric property 'numero' of module)
         $this->description = "Module commande fournisseur à partir d'une commande client";
         // Possible values for version are: 'development', 'experimental' or version
-        $this->version = '2.3.2';
+        $this->version = '2.3.3';
         // Key used in llx_const table to save module status enabled/disabled
         // (where MYMODULE is value of property name of module in uppercase)
         $this->const_name = 'MAIN_MODULE_' . strtoupper($this->name);

--- a/lib/function.lib.php
+++ b/lib/function.lib.php
@@ -296,7 +296,7 @@ function updateOrAddlineToSupplierOrder($CommandeFournisseur, $line, $productid,
 	if(!empty($productid)){
 		$ProductFournisseur = new ProductFournisseur($db);
 		if($ProductFournisseur->find_min_price_product_fournisseur($productid, $qty, $supplierSocId) > 0){
-			$price = floatval($ProductFournisseur->fourn_price); // floatval is used to remove non used zero
+			$price = floatval($ProductFournisseur->fourn_unitprice); // floatval is used to remove non used zero
 			$tva_tx = $ProductFournisseur->tva_tx;
 			$fk_prod_fourn_price = $ProductFournisseur->product_fourn_price_id;
 			$remise_percent = $ProductFournisseur->fourn_remise_percent;


### PR DESCRIPTION
# FIX : 
 Changement dans lib de $price = floatval($ProductFournisseur->fourn_unitprice); au lieu de price
    dans la fonction updateOrAddlineToSupplierOrder()
