### PR TITLE
PULLUP - FIX - le champ "fk_origin_line" dans la table llx_expeditiondet a été renommé "fk_elementdet"

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@
 
 
 ## RELEASES 2.9
+- FIX : Depuis la V20, le champ "fk_origin_line" dans la table llx_expeditiondet a été renommé "fk_elementdet" ce qui causait des erreurs - *22/10/2024* - 2.9.1
 - NEW : new coloumn on supplier order creation form : quantities already shipped - *03/09/2024* - 2.9.0
 
 ## RELEASES 2.8

--- a/core/modules/modSupplierorderfromorder.class.php
+++ b/core/modules/modSupplierorderfromorder.class.php
@@ -64,7 +64,7 @@ class modSupplierorderfromorder extends DolibarrModules
         $this->description = "Module commande fournisseur à partir d'une commande client";
         // Possible values for version are: 'development', 'experimental' or version
 
-        $this->version = '2.9.0';
+        $this->version = '2.9.1';
 		// Url to the file with your last numberversion of this module
 		require_once __DIR__ . '/../../class/techatm.class.php';
 		$this->url_last_version = \supplierorderfromorder\TechATM::getLastModuleVersionUrl($this);

--- a/ordercustomer.php
+++ b/ordercustomer.php
@@ -604,7 +604,12 @@ $sql .= ' FROM ' . $db->prefix() . 'commandedet';
 $sql .= ' GROUP BY fk_product, fk_commande';
 $sql .= ') as cd ON prod.rowid = cd.fk_product';
 
-$sql .= ' LEFT JOIN ' . $db->prefix() . 'expeditiondet as ed ON (cd.rowid = ed.fk_origin_line)';
+
+if ((float)DOL_VERSION >= 20.0) {
+	$sql .= ' LEFT JOIN ' . $db->prefix() . 'expeditiondet as ed ON (cd.rowid = ed.fk_elementdet)';
+}else{
+	$sql .= ' LEFT JOIN ' . $db->prefix() . 'expeditiondet as ed ON (cd.rowid = ed.fk_origin_line)';
+}
 
 if (!empty($TCategoriesQuery)) {
 	$sql .= ' LEFT OUTER JOIN ' . $db->prefix() . 'categorie_product as cp ON (prod.rowid = cp.fk_product)';
@@ -1067,7 +1072,7 @@ if ($resql || $resql2) {
 		$sortfield,
 		$sortorder
 	);
-	if ($conf->global->SOFO_QTY_LINES_COMES_FROM_ORIGIN_ORDER_ONLY) {
+	if (isset($conf->global->SOFO_QTY_LINES_COMES_FROM_ORIGIN_ORDER_ONLY)) {
 		print_liste_field_titre(
 			$langs->trans('AlreadyShipped'),
 			'ordercustomer.php',


### PR DESCRIPTION
PULLUP de [cette PR](https://github.com/ATM-Consulting/dolibarr_module_supplierorderfromorder/pull/168/files)